### PR TITLE
Support multiple FlightSQL Endpoints + Auth Options

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 readme.workspace = true
 
 [dev-dependencies]
+arrow-flight = { version = "49.0.0", features = ["flight-sql-experimental"] }
 tokio = "1.35.1"
 async-trait.workspace = true
 datafusion.workspace = true

--- a/examples/examples/flight-sql.rs
+++ b/examples/examples/flight-sql.rs
@@ -9,7 +9,10 @@ use datafusion::{
     },
 };
 use datafusion_federation::{FederatedQueryPlanner, FederationAnalyzerRule};
-use datafusion_federation_flight_sql::{executor::{FlightSQLAuth, FlightSQLExecutor}, server::FlightSqlService};
+use datafusion_federation_flight_sql::{
+    executor::{FlightSQLAuth, FlightSQLExecutor},
+    server::FlightSqlService,
+};
 use datafusion_federation_sql::{SQLFederationProvider, SQLSchemaProvider};
 use tokio::time::sleep;
 

--- a/examples/examples/flight-sql.rs
+++ b/examples/examples/flight-sql.rs
@@ -9,7 +9,7 @@ use datafusion::{
     },
 };
 use datafusion_federation::{FederatedQueryPlanner, FederationAnalyzerRule};
-use datafusion_federation_flight_sql::{executor::FlightSQLExecutor, server::FlightSqlService};
+use datafusion_federation_flight_sql::{executor::{FlightSQLAuth, FlightSQLExecutor}, server::FlightSqlService};
 use datafusion_federation_sql::{SQLFederationProvider, SQLSchemaProvider};
 use tokio::time::sleep;
 
@@ -49,7 +49,7 @@ async fn main() -> Result<()> {
     // Register schema
     // TODO: table inference
     let dsn: String = "http://localhost:50051".to_string();
-    let executor = Arc::new(FlightSQLExecutor::new(dsn));
+    let executor = Arc::new(FlightSQLExecutor::new(dsn, FlightSQLAuth::Unsecured));
     let provider = Arc::new(SQLFederationProvider::new(executor));
     let schema_provider = Arc::new(SQLSchemaProvider::new(provider, known_tables).await?);
     overwrite_default_schema(&state, schema_provider)?;

--- a/examples/examples/flight-sql.rs
+++ b/examples/examples/flight-sql.rs
@@ -1,5 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
+use arrow_flight::sql::client::FlightSqlServiceClient;
 use datafusion::{
     catalog::schema::SchemaProvider,
     error::{DataFusionError, Result},
@@ -9,15 +10,10 @@ use datafusion::{
     },
 };
 use datafusion_federation::{FederatedQueryPlanner, FederationAnalyzerRule};
-use datafusion_federation_flight_sql::{
-    executor::{FlightSQLExecutor},
-    server::FlightSqlService,
-};
+use datafusion_federation_flight_sql::{executor::FlightSQLExecutor, server::FlightSqlService};
 use datafusion_federation_sql::{SQLFederationProvider, SQLSchemaProvider};
 use tokio::time::sleep;
 use tonic::transport::Endpoint;
-use arrow_flight::{sql::client::FlightSqlServiceClient, FlightInfo};
-
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -86,9 +82,7 @@ fn overwrite_default_schema(state: &SessionState, schema: Arc<dyn SchemaProvider
 
 /// Creates a new [FlightSqlServiceClient] for the passed endpoint. Completes the relevant auth configurations
 /// or handshake as appropriate for the passed [FlightSQLAuth] variant.
-async fn new_client(
-    dsn: String,
-) -> Result<FlightSqlServiceClient<tonic::transport::Channel>> {
+async fn new_client(dsn: String) -> Result<FlightSqlServiceClient<tonic::transport::Channel>> {
     let endpoint = Endpoint::new(dsn).map_err(tx_error_to_df)?;
     let channel = endpoint.connect().await.map_err(tx_error_to_df)?;
     Ok(FlightSqlServiceClient::new(channel))

--- a/sources/flight-sql/Cargo.toml
+++ b/sources/flight-sql/Cargo.toml
@@ -15,7 +15,7 @@ datafusion.workspace = true
 datafusion-federation.path = "../../datafusion-federation"
 datafusion-federation-sql.path = "../sql"
 futures = "0.3.30"
-tonic = "0.10.2"
+tonic = {version="0.10.2", features=["tls"] }
 prost = "0.12.3"
 arrow = "49.0.0"
 arrow-flight = { version = "49.0.0", features = ["flight-sql-experimental"] }

--- a/sources/flight-sql/src/executor/mod.rs
+++ b/sources/flight-sql/src/executor/mod.rs
@@ -1,22 +1,50 @@
-use arrow::error::ArrowError;
-use arrow_flight::{sql::client::FlightSqlServiceClient, Ticket};
+use arrow::{datatypes::Schema, error::ArrowError, record_batch};
+use arrow_flight::{decode::FlightRecordBatchStream, error::FlightError, sql::client::FlightSqlServiceClient, FlightInfo, Ticket};
 use async_trait::async_trait;
 use datafusion::{
     error::{DataFusionError, Result},
     physical_plan::{stream::RecordBatchStreamAdapter, SendableRecordBatchStream},
 };
 use datafusion_federation_sql::SQLExecutor;
-use futures::{executor, StreamExt};
+use futures::{executor, StreamExt, TryStreamExt};
+use log::Record;
 use std::sync::Arc;
-use tonic::transport::Endpoint;
+use tonic::transport::{Certificate, ClientTlsConfig, Endpoint, Identity};
+
+/// Authentication options for FlightSQL Endpoints
+#[derive(Clone)]
+pub enum FlightSQLAuth{
+    Basic(BasicAuth),
+    PKI(PKIAuth),
+    Unsecured
+}
+
+/// Basic username and password authorization for FlightSQL Endpoints
+#[derive(Clone)]
+pub struct BasicAuth{
+    username: String,
+    password: String,
+}
+
+/// Contains options for completing mTLS/PKI authentication configuration of Tonic client
+#[derive(Clone)]
+pub struct PKIAuth {
+    /// The public x509 cert pem file used to auth with the FlightSQL server
+    pub client_cert_file: String,
+    /// The private key pem file used to validate the public client cert
+    pub client_key_file: String,
+    /// The bundle of trusted CAcerts for validating the FlightSQL server
+    pub ca_cert_bundle: String,
+}
 
 pub struct FlightSQLExecutor {
     context: String,
+    auth: FlightSQLAuth
 }
 
 impl FlightSQLExecutor {
-    pub fn new(dsn: String) -> Self {
-        Self { context: dsn }
+    pub fn new(dns: String, auth: FlightSQLAuth) -> Self {
+        Self { context: dns , auth}
     }
 
     pub fn context(&mut self, context: String) {
@@ -24,11 +52,58 @@ impl FlightSQLExecutor {
     }
 }
 
-async fn new_client(dns: String) -> Result<FlightSqlServiceClient<tonic::transport::Channel>> {
-    let endpoint = Endpoint::new(dns.clone()).map_err(tx_error_to_df)?;
-    let channel = endpoint.connect().await.map_err(tx_error_to_df)?;
+/// Creates a new [FlightSqlServiceClient] for the passed endpoint. Completes the relevant auth configurations
+/// or handshake as appropriate for the passed [FlightSQLAuth] variant.
+async fn new_client(dns: String, auth: FlightSQLAuth) -> Result<FlightSqlServiceClient<tonic::transport::Channel>> {
+    let endpoint = Endpoint::new(dns).map_err(tx_error_to_df)?;
+    
+    match auth{
+        FlightSQLAuth::Basic(basic) =>{
+            let channel = endpoint.connect().await.map_err(tx_error_to_df)?;
+            let mut client = FlightSqlServiceClient::new(channel);
+            client
+                .handshake(basic.username.as_str(), basic.password.as_str())
+                .await?;
+            Ok(client)
+        },
+        FlightSQLAuth::PKI(pki) => {
+            let endpoint = endpoint.tls_config(
+                ClientTlsConfig::new()
+                    .identity(Identity::from_pem(
+                        pki.client_cert_file.as_str(),
+                        pki.client_key_file.as_str(),
+                    ))
+                    .ca_certificate(Certificate::from_pem(pki.ca_cert_bundle.as_str())),
+            ).map_err(tx_error_to_df)?;
+            let channel = endpoint.connect().await.map_err(tx_error_to_df)?;
+            Ok(FlightSqlServiceClient::new(channel))
+        },
+        FlightSQLAuth::Unsecured => {
+            let channel = endpoint.connect().await.map_err(tx_error_to_df)?;
+            Ok(FlightSqlServiceClient::new(channel))
+        }
+    }
+}
 
-    Ok(FlightSqlServiceClient::new(channel))
+async fn make_flight_sql_stream(
+    dns: String, 
+    auth: FlightSQLAuth,
+    flight_info: FlightInfo,
+    schema: Arc<Schema>) -> Result<SendableRecordBatchStream>{
+    let client = &mut new_client(dns, auth).await?;
+    let mut flight_data_streams = Vec::with_capacity(flight_info.endpoint.len());
+    for endpoint in flight_info.endpoint {
+        let ticket = endpoint.ticket.ok_or(DataFusionError::Execution(
+            "FlightEndpoint missing ticket!".to_string(),
+        ))?;
+        let flight_data = client.do_get(ticket).await?;
+        flight_data_streams.push(flight_data);
+    }
+
+    let record_batch_stream = futures::stream::select_all(flight_data_streams)
+        .map_err(|e| DataFusionError::External(Box::new(e)));
+
+    Ok(Box::pin(RecordBatchStreamAdapter::new(schema, record_batch_stream)))
 }
 
 #[async_trait]
@@ -40,58 +115,29 @@ impl SQLExecutor for FlightSQLExecutor {
         Some(self.context.clone())
     }
     fn execute(&self, sql: &str) -> Result<SendableRecordBatchStream> {
-        let dsn = self.context.clone();
+        let dns = self.context.clone();
+        let auth = self.auth.clone();
         let flight_info = executor::block_on(async move {
-            let client = &mut new_client(dsn).await?;
+            let client = &mut new_client(dns, auth.clone()).await?;
             client.execute(sql.to_string(), None).await
         })
         .map_err(arrow_error_to_df)?;
-        let ticket = flight_info.endpoint[0].ticket.as_ref().unwrap().clone();
-        let schema = flight_info.try_decode_schema().map_err(arrow_error_to_df)?;
+        
+        let schema = Arc::new(flight_info.clone().try_decode_schema().map_err(arrow_error_to_df)?);
 
-        let stream = futures::stream::try_unfold(
-            (
-                None,
-                Some(InitStream {
-                    dsn: self.context.clone(),
-                    ticket,
-                }),
-            ),
-            |(maybe_stream, maybe_init)| async move {
-                let mut stream = match maybe_stream {
-                    Some(stream) => stream,
-                    None => {
-                        let init = maybe_init.unwrap();
-                        let client = &mut new_client(init.dsn).await?;
-                        client
-                            .do_get(init.ticket)
-                            .await
-                            .map_err(arrow_error_to_df)?
-                    }
-                };
-                let maybe_batch = stream
-                    .next()
-                    .await
-                    .transpose()
-                    .map_err(|e| DataFusionError::External(Box::new(e)))?;
-
-                match maybe_batch {
-                    Some(batch) => Ok::<_, DataFusionError>(Some((batch, (Some(stream), None)))),
-                    None => Ok(None),
-                }
-            },
+        let future_stream = make_flight_sql_stream(
+            self.context.clone(), 
+            self.auth.clone(),
+            flight_info, 
+            schema.clone()
         );
+        let stream = futures::stream::once(future_stream).try_flatten();
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(
-            Arc::new(schema),
+            schema,
             stream,
         )))
     }
-}
-
-struct InitStream {
-    dsn: String,
-    ticket: Ticket,
 }
 
 fn tx_error_to_df(err: tonic::transport::Error) -> DataFusionError {

--- a/sources/flight-sql/src/executor/mod.rs
+++ b/sources/flight-sql/src/executor/mod.rs
@@ -29,12 +29,12 @@ pub struct BasicAuth {
 /// Contains options for completing mTLS/PKI authentication configuration of Tonic client
 #[derive(Clone)]
 pub struct PKIAuth {
-    /// The public x509 cert pem file used to auth with the FlightSQL server
-    pub client_cert_file: String,
-    /// The private key pem file used to validate the public client cert
-    pub client_key_file: String,
+    /// The public x509 cert pem encoded used to auth with the FlightSQL server
+    pub client_cert_file: Arc<[u8]>,
+    /// The private key pem encoded used to validate the public client cert
+    pub client_key_file: Arc<[u8]>,
     /// The bundle of trusted CAcerts for validating the FlightSQL server
-    pub ca_cert_bundle: String,
+    pub ca_cert_bundle: Arc<[u8]>,
 }
 
 pub struct FlightSQLExecutor {
@@ -74,10 +74,10 @@ async fn new_client(
                 .tls_config(
                     ClientTlsConfig::new()
                         .identity(Identity::from_pem(
-                            pki.client_cert_file.as_str(),
-                            pki.client_key_file.as_str(),
+                            pki.client_cert_file.as_ref(),
+                            pki.client_key_file.as_ref(),
                         ))
-                        .ca_certificate(Certificate::from_pem(pki.ca_cert_bundle.as_str())),
+                        .ca_certificate(Certificate::from_pem(pki.ca_cert_bundle.as_ref())),
                 )
                 .map_err(tx_error_to_df)?;
             let channel = endpoint.connect().await.map_err(tx_error_to_df)?;


### PR DESCRIPTION
This PR adds support for the following FlightSQL features:

- Combining multiple streams in the case the returned Ticket has multiple endpoints 
- Support basic and PKI auth

I also attempting refactoring according to DataFusion's suggested practice when needing to call async methods within the execute method of a physical plan. As discussed on the prior PR, it is still painful to obtain the schema even when following this method. I do think it is slightly cleaner than `try_unfold` and can be cleaned up further if we figure out a better way to obtain the expected schema of the flight stream.