### PR TITLE
Pass VirtualExecutionPlan Schema to SQLExecutors

### DIFF
--- a/sources/flight-sql/src/executor/mod.rs
+++ b/sources/flight-sql/src/executor/mod.rs
@@ -1,4 +1,4 @@
-use arrow::{datatypes::Schema, error::ArrowError};
+use arrow::{datatypes::{Schema, SchemaRef}, error::ArrowError};
 use arrow_flight::{sql::client::FlightSqlServiceClient, FlightInfo};
 use async_trait::async_trait;
 use datafusion::{
@@ -30,10 +30,13 @@ impl FlightSQLExecutor {
 }
 
 async fn make_flight_sql_stream(
+    sql: String,
     mut client: FlightSqlServiceClient<Channel>,
-    flight_info: FlightInfo,
-    schema: Arc<Schema>,
+    schema: SchemaRef,
 ) -> Result<SendableRecordBatchStream> {
+    let flight_info = client.execute(sql.to_string(), None).await
+            .map_err(arrow_error_to_df)?;
+
     let mut flight_data_streams = Vec::with_capacity(flight_info.endpoint.len());
     for endpoint in flight_info.endpoint {
         let ticket = endpoint.ticket.ok_or(DataFusionError::Execution(
@@ -60,24 +63,20 @@ impl SQLExecutor for FlightSQLExecutor {
     fn compute_context(&self) -> Option<String> {
         Some(self.context.clone())
     }
-    fn execute(&self, sql: &str) -> Result<SendableRecordBatchStream> {
-        let mut client = self.client.clone();
-        let flight_info =
-            executor::block_on(async move { client.execute(sql.to_string(), None).await })
-                .map_err(arrow_error_to_df)?;
-
-        let schema = Arc::new(
-            flight_info
-                .clone()
-                .try_decode_schema()
-                .map_err(arrow_error_to_df)?,
-        );
-
+    fn execute(&self, sql: &str, schema: SchemaRef) -> Result<SendableRecordBatchStream> {
         let future_stream =
-            make_flight_sql_stream(self.client.clone(), flight_info, schema.clone());
+            make_flight_sql_stream(sql.to_string(), self.client.clone(), schema.clone());
         let stream = futures::stream::once(future_stream).try_flatten();
 
-        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema.clone(), stream)))
+    }
+
+    async fn get_table_schema(&self, table_name: &str) -> Result<SchemaRef>{
+        let sql = format!("select * from {table_name} limit 1");
+        let flight_info = self.client.clone().execute(sql, None).await
+            .map_err(arrow_error_to_df)?;
+        let schema = flight_info.try_decode_schema().map_err(arrow_error_to_df)?;
+        Ok(Arc::new(schema))
     }
 }
 

--- a/sources/flight-sql/src/executor/mod.rs
+++ b/sources/flight-sql/src/executor/mod.rs
@@ -1,12 +1,12 @@
-use arrow::{datatypes::{Schema, SchemaRef}, error::ArrowError};
-use arrow_flight::{sql::client::FlightSqlServiceClient, FlightInfo};
+use arrow::{datatypes::SchemaRef, error::ArrowError};
+use arrow_flight::sql::client::FlightSqlServiceClient;
 use async_trait::async_trait;
 use datafusion::{
     error::{DataFusionError, Result},
     physical_plan::{stream::RecordBatchStreamAdapter, SendableRecordBatchStream},
 };
 use datafusion_federation_sql::SQLExecutor;
-use futures::{executor, TryStreamExt};
+use futures::TryStreamExt;
 
 use std::sync::Arc;
 use tonic::transport::Channel;
@@ -34,8 +34,10 @@ async fn make_flight_sql_stream(
     mut client: FlightSqlServiceClient<Channel>,
     schema: SchemaRef,
 ) -> Result<SendableRecordBatchStream> {
-    let flight_info = client.execute(sql.to_string(), None).await
-            .map_err(arrow_error_to_df)?;
+    let flight_info = client
+        .execute(sql.to_string(), None)
+        .await
+        .map_err(arrow_error_to_df)?;
 
     let mut flight_data_streams = Vec::with_capacity(flight_info.endpoint.len());
     for endpoint in flight_info.endpoint {
@@ -68,12 +70,19 @@ impl SQLExecutor for FlightSQLExecutor {
             make_flight_sql_stream(sql.to_string(), self.client.clone(), schema.clone());
         let stream = futures::stream::once(future_stream).try_flatten();
 
-        Ok(Box::pin(RecordBatchStreamAdapter::new(schema.clone(), stream)))
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            schema.clone(),
+            stream,
+        )))
     }
 
-    async fn get_table_schema(&self, table_name: &str) -> Result<SchemaRef>{
+    async fn get_table_schema(&self, table_name: &str) -> Result<SchemaRef> {
         let sql = format!("select * from {table_name} limit 1");
-        let flight_info = self.client.clone().execute(sql, None).await
+        let flight_info = self
+            .client
+            .clone()
+            .execute(sql, None)
+            .await
             .map_err(arrow_error_to_df)?;
         let schema = flight_info.try_decode_schema().map_err(arrow_error_to_df)?;
         Ok(Arc::new(schema))

--- a/sources/sql/src/connectorx/executor.rs
+++ b/sources/sql/src/connectorx/executor.rs
@@ -68,9 +68,11 @@ impl SQLExecutor for CXExecutor {
         Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
     }
 
-    async fn get_table_schema(&self, table_name: &str) -> Result<SchemaRef>{
+    async fn get_table_schema(&self, table_name: &str) -> Result<SchemaRef> {
         let conn = self.conn.clone();
-        let query: CXQuery = format!("select * from {table_name} limit 1").as_str().into();
+        let query: CXQuery = format!("select * from {table_name} limit 1")
+            .as_str()
+            .into();
 
         let dst = get_arrow(&conn, None, &[query.clone()]).map_err(cx_out_error_to_df)?;
         let schema = schema_to_lowercase(dst.arrow_schema());

--- a/sources/sql/src/connectorx/executor.rs
+++ b/sources/sql/src/connectorx/executor.rs
@@ -50,7 +50,7 @@ impl SQLExecutor for CXExecutor {
     fn compute_context(&self) -> Option<String> {
         Some(self.context.clone())
     }
-    fn execute(&self, sql: &str) -> Result<SendableRecordBatchStream> {
+    fn execute(&self, sql: &str, _schema: SchemaRef) -> Result<SendableRecordBatchStream> {
         let conn = self.conn.clone();
         let query: CXQuery = sql.into();
 
@@ -66,6 +66,15 @@ impl SQLExecutor for CXExecutor {
         let schema = schema_to_lowercase(dst.arrow_schema());
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+
+    async fn get_table_schema(&self, table_name: &str) -> Result<SchemaRef>{
+        let conn = self.conn.clone();
+        let query: CXQuery = format!("select * from {table_name} limit 1").as_str().into();
+
+        let dst = get_arrow(&conn, None, &[query.clone()]).map_err(cx_out_error_to_df)?;
+        let schema = schema_to_lowercase(dst.arrow_schema());
+        Ok(schema)
     }
 }
 

--- a/sources/sql/src/executor.rs
+++ b/sources/sql/src/executor.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use core::fmt;
-use datafusion::{error::Result, physical_plan::SendableRecordBatchStream};
+use datafusion::{arrow::datatypes::{Schema, SchemaRef}, error::Result, physical_plan::SendableRecordBatchStream};
 use std::sync::Arc;
 
 pub type SQLExecutorRef = Arc<dyn SQLExecutor>;
@@ -9,7 +9,9 @@ pub type SQLExecutorRef = Arc<dyn SQLExecutor>;
 pub trait SQLExecutor: Sync + Send {
     fn name(&self) -> &str;
     fn compute_context(&self) -> Option<String>;
-    fn execute(&self, query: &str) -> Result<SendableRecordBatchStream>;
+    fn execute(&self, query: &str, schema: SchemaRef) -> Result<SendableRecordBatchStream>;
+    /// Returns the schema of table_name within this SQLExecutor
+    async fn get_table_schema(&self, table_name: &str) -> Result<SchemaRef>;
 }
 
 impl fmt::Debug for dyn SQLExecutor {

--- a/sources/sql/src/executor.rs
+++ b/sources/sql/src/executor.rs
@@ -1,6 +1,8 @@
 use async_trait::async_trait;
 use core::fmt;
-use datafusion::{arrow::datatypes::{Schema, SchemaRef}, error::Result, physical_plan::SendableRecordBatchStream};
+use datafusion::{
+    arrow::datatypes::SchemaRef, error::Result, physical_plan::SendableRecordBatchStream,
+};
 use std::sync::Arc;
 
 pub type SQLExecutorRef = Arc<dyn SQLExecutor>;

--- a/sources/sql/src/lib.rs
+++ b/sources/sql/src/lib.rs
@@ -171,6 +171,6 @@ impl ExecutionPlan for VirtualExecutionPlan {
         let ast = query_to_sql(&self.plan)?;
         let query = format!("{ast}");
 
-        self.executor.execute(query.as_str())
+        self.executor.execute(query.as_str(), self.schema())
     }
 }

--- a/sources/sql/src/schema.rs
+++ b/sources/sql/src/schema.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use datafusion::arrow::datatypes::Schema;
 use datafusion::logical_expr::{TableSource, TableType};
 use datafusion::{
     arrow::datatypes::SchemaRef, catalog::schema::SchemaProvider, datasource::TableProvider,
@@ -71,10 +72,7 @@ struct SQLTableSource {
 impl SQLTableSource {
     // creates a SQLTableSource and infers the table schema
     pub async fn new(provider: Arc<SQLFederationProvider>, table_name: String) -> Result<Self> {
-        // Simple schema inference
-        let query = format!("SELECT * FROM {table_name} LIMIT 1");
-        let schema = provider.clone().executor.execute(query.as_str())?.schema();
-
+        let schema = provider.clone().executor.get_table_schema(table_name.as_str()).await?;
         Self::new_with_schema(provider, table_name, schema)
     }
 

--- a/sources/sql/src/schema.rs
+++ b/sources/sql/src/schema.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use datafusion::arrow::datatypes::Schema;
+
 use datafusion::logical_expr::{TableSource, TableType};
 use datafusion::{
     arrow::datatypes::SchemaRef, catalog::schema::SchemaProvider, datasource::TableProvider,
@@ -72,7 +72,11 @@ struct SQLTableSource {
 impl SQLTableSource {
     // creates a SQLTableSource and infers the table schema
     pub async fn new(provider: Arc<SQLFederationProvider>, table_name: String) -> Result<Self> {
-        let schema = provider.clone().executor.get_table_schema(table_name.as_str()).await?;
+        let schema = provider
+            .clone()
+            .executor
+            .get_table_schema(table_name.as_str())
+            .await?;
         Self::new_with_schema(provider, table_name, schema)
     }
 


### PR DESCRIPTION
This PR simplifies FlightSQL Execution plans by relying on the VirtualExecutionPlan inferred from the sub-logical plan sliced out of the overall query to infer the schema. This avoids the need for block_on and simplifies the code further. 

Additionally, I added a new async trait method `get_table_schema` so SQLExecutors can implement arbitrary logic to return what the overall table schema of each table is. 