### PR TITLE
Intial support for substrait on flightsql server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ readme = "README.md"
 [workspace.dependencies]
 async-trait = "0.1.77"
 datafusion = "34.0.0"
+datafusion-substrait = "34.0.0"

--- a/sources/flight-sql/Cargo.toml
+++ b/sources/flight-sql/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 [dependencies]
 async-trait.workspace = true
 datafusion.workspace = true
+datafusion-substrait.workspace = true
 datafusion-federation.path = "../../datafusion-federation"
 datafusion-federation-sql.path = "../sql"
 futures = "0.3.30"


### PR DESCRIPTION
This PR implements initial minimal support for  executing a substrait plan via DataFusion on the FlightSQL server.