### PR TITLE
feat: add support for producing SQL in multiple dialects

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -16,5 +16,9 @@ datafusion-federation-flight-sql.path = "../sources/flight-sql"
 connectorx = { git = "https://github.com/sfu-db/connector-x.git", rev = "fa0fc7bc", features = [
     "dst_arrow",
     "src_sqlite",
+    "src_postgres",
 ] }
 tonic = "0.10.2"
+
+[dependencies]
+async-std = "1.12.0"

--- a/examples/examples/postgres-partial.rs
+++ b/examples/examples/postgres-partial.rs
@@ -47,7 +47,7 @@ async fn create_postgres_provider(
     known_tables: Vec<&str>,
     context: &str,
 ) -> Result<Arc<SQLSchemaProvider>> {
-    let dsn = "postgresql://Suriya:password@localhost:28816/pg_analytics".to_string();
+    let dsn = "postgresql://<username>:<password>@localhost:<port>/<dbname>".to_string();
     let known_tables: Vec<String> = known_tables.iter().map(|&x| x.into()).collect();
     let mut executor = CXExecutor::new(dsn)?;
     executor.context(context.to_string());

--- a/examples/examples/postgres-partial.rs
+++ b/examples/examples/postgres-partial.rs
@@ -1,0 +1,119 @@
+use std::{any::Any, sync::Arc};
+use tokio::task;
+
+use async_trait::async_trait;
+use datafusion::{
+    catalog::schema::SchemaProvider,
+    datasource::TableProvider,
+    error::Result,
+    execution::context::{SessionContext, SessionState},
+};
+use datafusion_federation::{FederatedQueryPlanner, FederationAnalyzerRule};
+use datafusion_federation_sql::{SQLFederationProvider, SQLSchemaProvider};
+use datafusion_federation_sql::cx_executor::CXExecutor;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let state = SessionContext::new().state();
+    // Register FederationAnalyzer
+    // TODO: Interaction with other analyzers & optimizers.
+    let state = state
+        .add_analyzer_rule(Arc::new(FederationAnalyzerRule::new()))
+        .with_query_planner(Arc::new(FederatedQueryPlanner::new()));
+
+let df = task::spawn_blocking(move || {
+    // Register schema
+    let pg_provider = async_std::task::block_on(create_postgres_provider(vec!["person"], "conn1")).unwrap();
+    let pg_col_provider = async_std::task::block_on(create_postgres_provider(vec!["job"], "conn2")).unwrap();
+    let provider = MultiSchemaProvider::new(vec![
+        pg_provider,
+        pg_col_provider,
+    ]);
+
+    overwrite_default_schema(&state, Arc::new(provider)).unwrap();
+
+    // Run query
+    let ctx = SessionContext::new_with_state(state);
+    let query = r#"SELECT person.name AS PersonName, job.title AS JobName, person.age AS Age
+            FROM person JOIN job ON person.age = job.age"#;
+        let df = async_std::task::block_on(ctx.sql(query)).unwrap();
+
+        df
+    }).await.unwrap();
+
+    task::spawn_blocking(move || { async_std::task::block_on(df.show()) }).await.unwrap();
+}
+
+async fn create_sqlite_provider(
+    known_tables: Vec<&str>,
+    context: &str,
+) -> Result<Arc<SQLSchemaProvider>> {
+    let dsn = "sqlite://./examples/examples/chinook.sqlite".to_string();
+    let known_tables: Vec<String> = known_tables.iter().map(|&x| x.into()).collect();
+    let mut executor = CXExecutor::new(dsn)?;
+    executor.context(context.to_string());
+    let provider = Arc::new(SQLFederationProvider::new(Arc::new(executor)));
+    Ok(Arc::new(
+        SQLSchemaProvider::new(provider, known_tables).await?,
+    ))
+}
+
+async fn create_postgres_provider(
+    known_tables: Vec<&str>,
+    context: &str,
+) -> Result<Arc<SQLSchemaProvider>> {
+    let dsn = "postgresql://user:password@localhost:5432/testdb".to_string();
+    let known_tables: Vec<String> = known_tables.iter().map(|&x| x.into()).collect();
+    let mut executor = CXExecutor::new(dsn)?;
+    executor.context(context.to_string());
+    let provider = Arc::new(SQLFederationProvider::new(Arc::new(executor)));
+    Ok(Arc::new(
+        SQLSchemaProvider::new(provider, known_tables).await?,
+    ))
+}
+
+struct MultiSchemaProvider {
+    children: Vec<Arc<dyn SchemaProvider>>,
+}
+
+impl MultiSchemaProvider {
+    pub fn new(children: Vec<Arc<dyn SchemaProvider>>) -> Self {
+        Self { children }
+    }
+}
+
+fn overwrite_default_schema(state: &SessionState, schema: Arc<dyn SchemaProvider>) -> Result<()> {
+    let options = &state.config().options().catalog;
+    let catalog = state
+        .catalog_list()
+        .catalog(options.default_catalog.as_str())
+        .unwrap();
+
+    catalog.register_schema(options.default_schema.as_str(), schema)?;
+
+    Ok(())
+}
+
+#[async_trait]
+impl SchemaProvider for MultiSchemaProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn table_names(&self) -> Vec<String> {
+        self.children.iter().flat_map(|p| p.table_names()).collect()
+    }
+
+    async fn table(&self, name: &str) -> Option<Arc<dyn TableProvider>> {
+        for child in &self.children {
+            if let Some(table) = child.table(name).await {
+                return Some(table);
+            }
+        }
+        None
+    }
+
+    fn table_exist(&self, name: &str) -> bool {
+        self.children.iter().any(|p| p.table_exist(name))
+    }
+}

--- a/examples/examples/postgres-partial.rs
+++ b/examples/examples/postgres-partial.rs
@@ -7,8 +7,8 @@ use datafusion::{
     execution::context::{SessionContext, SessionState},
 };
 use datafusion_federation::{FederatedQueryPlanner, FederationAnalyzerRule};
-use datafusion_federation_sql::{MultiSchemaProvider, SQLFederationProvider, SQLSchemaProvider};
 use datafusion_federation_sql::connectorx::CXExecutor;
+use datafusion_federation_sql::{MultiSchemaProvider, SQLFederationProvider, SQLSchemaProvider};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -19,33 +19,35 @@ async fn main() -> Result<()> {
         .add_analyzer_rule(Arc::new(FederationAnalyzerRule::new()))
         .with_query_planner(Arc::new(FederatedQueryPlanner::new()));
 
-let df = task::spawn_blocking(move || {
+    let df = task::spawn_blocking(move || {
     // Register schema
-    let pg_provider = async_std::task::block_on(create_postgres_provider(vec!["class"], "conn1")).unwrap();
-    let pg_col_provider = async_std::task::block_on(create_postgres_provider(vec!["teacher"], "conn2")).unwrap();
+    let pg_provider_1 = async_std::task::block_on(create_postgres_provider(vec!["class"], "conn1")).unwrap();
+    let pg_provider_2 = async_std::task::block_on(create_postgres_provider(vec!["teacher"], "conn2")).unwrap();
     let provider = MultiSchemaProvider::new(vec![
-        pg_provider,
-        pg_col_provider,
+        pg_provider_1,
+        pg_provider_2,
     ]);
 
     overwrite_default_schema(&state, Arc::new(provider)).unwrap();
 
     // Run query
     let ctx = SessionContext::new_with_state(state);
-    let query = r#"SELECT class.name AS classname, teacher.name as teachername from class join teacher on class.id = teacher.class_id;"#;
-        let df = async_std::task::block_on(ctx.sql(query)).unwrap();
+    let query = r#"SELECT class.name AS classname, teacher.name AS teachername FROM class JOIN teacher ON class.id = teacher.class_id"#;
+    let df = async_std::task::block_on(ctx.sql(query)).unwrap();
 
         df
     }).await.unwrap();
 
-    task::spawn_blocking(move || { async_std::task::block_on(df.show()) }).await.unwrap()
+    task::spawn_blocking(move || async_std::task::block_on(df.show()))
+        .await
+        .unwrap()
 }
 
 async fn create_postgres_provider(
     known_tables: Vec<&str>,
     context: &str,
 ) -> Result<Arc<SQLSchemaProvider>> {
-    let dsn = "postgresql://suriya-retake:password@localhost:28816/pg_analytics".to_string();
+    let dsn = "postgresql://Suriya:password@localhost:28816/pg_analytics".to_string();
     let known_tables: Vec<String> = known_tables.iter().map(|&x| x.into()).collect();
     let mut executor = CXExecutor::new(dsn)?;
     executor.context(context.to_string());
@@ -53,16 +55,6 @@ async fn create_postgres_provider(
     Ok(Arc::new(
         SQLSchemaProvider::new_with_tables(provider, known_tables).await?,
     ))
-}
-
-struct MultiSchemaProvider {
-    children: Vec<Arc<dyn SchemaProvider>>,
-}
-
-impl MultiSchemaProvider {
-    pub fn new(children: Vec<Arc<dyn SchemaProvider>>) -> Self {
-        Self { children }
-    }
 }
 
 fn overwrite_default_schema(state: &SessionState, schema: Arc<dyn SchemaProvider>) -> Result<()> {
@@ -75,28 +67,4 @@ fn overwrite_default_schema(state: &SessionState, schema: Arc<dyn SchemaProvider
     catalog.register_schema(options.default_schema.as_str(), schema)?;
 
     Ok(())
-}
-
-#[async_trait]
-impl SchemaProvider for MultiSchemaProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn table_names(&self) -> Vec<String> {
-        self.children.iter().flat_map(|p| p.table_names()).collect()
-    }
-
-    async fn table(&self, name: &str) -> Option<Arc<dyn TableProvider>> {
-        for child in &self.children {
-            if let Some(table) = child.table(name).await {
-                return Some(table);
-            }
-        }
-        None
-    }
-
-    fn table_exist(&self, name: &str) -> bool {
-        self.children.iter().any(|p| p.table_exist(name))
-    }
 }

--- a/examples/examples/postgres-partial.rs
+++ b/examples/examples/postgres-partial.rs
@@ -1,16 +1,14 @@
-use std::{any::Any, sync::Arc};
+use std::sync::Arc;
 use tokio::task;
 
-use async_trait::async_trait;
 use datafusion::{
     catalog::schema::SchemaProvider,
-    datasource::TableProvider,
     error::Result,
     execution::context::{SessionContext, SessionState},
 };
 use datafusion_federation::{FederatedQueryPlanner, FederationAnalyzerRule};
-use datafusion_federation_sql::{SQLFederationProvider, SQLSchemaProvider};
-use datafusion_federation_sql::cx_executor::CXExecutor;
+use datafusion_federation_sql::{MultiSchemaProvider, SQLFederationProvider, SQLSchemaProvider};
+use datafusion_federation_sql::connectorx::CXExecutor;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -23,8 +21,8 @@ async fn main() -> Result<()> {
 
 let df = task::spawn_blocking(move || {
     // Register schema
-    let pg_provider = async_std::task::block_on(create_postgres_provider(vec!["person"], "conn1")).unwrap();
-    let pg_col_provider = async_std::task::block_on(create_postgres_provider(vec!["job"], "conn2")).unwrap();
+    let pg_provider = async_std::task::block_on(create_postgres_provider(vec!["class"], "conn1")).unwrap();
+    let pg_col_provider = async_std::task::block_on(create_postgres_provider(vec!["teacher"], "conn2")).unwrap();
     let provider = MultiSchemaProvider::new(vec![
         pg_provider,
         pg_col_provider,
@@ -34,41 +32,26 @@ let df = task::spawn_blocking(move || {
 
     // Run query
     let ctx = SessionContext::new_with_state(state);
-    let query = r#"SELECT person.name AS PersonName, job.title AS JobName, person.age AS Age
-            FROM person JOIN job ON person.age = job.age"#;
+    let query = r#"SELECT class.name AS classname, teacher.name as teachername from class join teacher on class.id = teacher.class_id;"#;
         let df = async_std::task::block_on(ctx.sql(query)).unwrap();
 
         df
     }).await.unwrap();
 
-    task::spawn_blocking(move || { async_std::task::block_on(df.show()) }).await.unwrap();
-}
-
-async fn create_sqlite_provider(
-    known_tables: Vec<&str>,
-    context: &str,
-) -> Result<Arc<SQLSchemaProvider>> {
-    let dsn = "sqlite://./examples/examples/chinook.sqlite".to_string();
-    let known_tables: Vec<String> = known_tables.iter().map(|&x| x.into()).collect();
-    let mut executor = CXExecutor::new(dsn)?;
-    executor.context(context.to_string());
-    let provider = Arc::new(SQLFederationProvider::new(Arc::new(executor)));
-    Ok(Arc::new(
-        SQLSchemaProvider::new(provider, known_tables).await?,
-    ))
+    task::spawn_blocking(move || { async_std::task::block_on(df.show()) }).await.unwrap()
 }
 
 async fn create_postgres_provider(
     known_tables: Vec<&str>,
     context: &str,
 ) -> Result<Arc<SQLSchemaProvider>> {
-    let dsn = "postgresql://user:password@localhost:5432/testdb".to_string();
+    let dsn = "postgresql://suriya-retake:password@localhost:28816/pg_analytics".to_string();
     let known_tables: Vec<String> = known_tables.iter().map(|&x| x.into()).collect();
     let mut executor = CXExecutor::new(dsn)?;
     executor.context(context.to_string());
     let provider = Arc::new(SQLFederationProvider::new(Arc::new(executor)));
     Ok(Arc::new(
-        SQLSchemaProvider::new(provider, known_tables).await?,
+        SQLSchemaProvider::new_with_tables(provider, known_tables).await?,
     ))
 }
 

--- a/sources/flight-sql/src/executor/mod.rs
+++ b/sources/flight-sql/src/executor/mod.rs
@@ -93,6 +93,10 @@ impl SQLExecutor for FlightSQLExecutor {
         let schema = flight_info.try_decode_schema().map_err(arrow_error_to_df)?;
         Ok(Arc::new(schema))
     }
+
+    fn dialect(&self) -> &str {
+        "flight"
+    }
 }
 
 fn arrow_error_to_df(err: ArrowError) -> DataFusionError {

--- a/sources/flight-sql/src/executor/mod.rs
+++ b/sources/flight-sql/src/executor/mod.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use datafusion::{
     error::{DataFusionError, Result},
     physical_plan::{stream::RecordBatchStreamAdapter, SendableRecordBatchStream},
+    sql::sqlparser::dialect::{Dialect, GenericDialect},
 };
 use datafusion_federation_sql::SQLExecutor;
 use futures::TryStreamExt;
@@ -94,8 +95,8 @@ impl SQLExecutor for FlightSQLExecutor {
         Ok(Arc::new(schema))
     }
 
-    fn dialect(&self) -> &str {
-        "flight"
+    fn dialect(&self) -> Arc<dyn Dialect> {
+        Arc::new(GenericDialect {})
     }
 }
 

--- a/sources/sql/src/connectorx/executor.rs
+++ b/sources/sql/src/connectorx/executor.rs
@@ -84,6 +84,14 @@ impl SQLExecutor for CXExecutor {
         let schema = schema_to_lowercase(dst.arrow_schema());
         Ok(schema)
     }
+
+    fn dialect(&self) -> &str {
+        match &self.conn.ty {
+            SourceType::Postgres => "postgres",
+            SourceType::SQLite => "sqlite",
+            _ => todo!(),
+        }
+    }
 }
 
 fn cx_dst_error_to_df(err: ArrowDestinationError) -> DataFusionError {

--- a/sources/sql/src/executor.rs
+++ b/sources/sql/src/executor.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use core::fmt;
 use datafusion::{
     arrow::datatypes::SchemaRef, error::Result, physical_plan::SendableRecordBatchStream,
+    sql::sqlparser::dialect::Dialect,
 };
 use std::sync::Arc;
 
@@ -17,7 +18,7 @@ pub trait SQLExecutor: Sync + Send {
     fn compute_context(&self) -> Option<String>;
 
     // The specific SQL dialect (currently supports 'sqlite', 'postgres', 'flight')
-    fn dialect(&self) -> &str;
+    fn dialect(&self) -> Arc<dyn Dialect>;
 
     // Execution
     /// Execute a SQL query

--- a/sources/sql/src/executor.rs
+++ b/sources/sql/src/executor.rs
@@ -16,6 +16,9 @@ pub trait SQLExecutor: Sync + Send {
     /// such as authorization or active database.
     fn compute_context(&self) -> Option<String>;
 
+    // The specific SQL dialect (currently supports 'sqlite', 'postgres', 'flight')
+    fn dialect(&self) -> &str;
+
     // Execution
     /// Execute a SQL query
     fn execute(&self, query: &str, schema: SchemaRef) -> Result<SendableRecordBatchStream>;

--- a/sources/sql/src/lib.rs
+++ b/sources/sql/src/lib.rs
@@ -168,7 +168,7 @@ impl ExecutionPlan for VirtualExecutionPlan {
         _partition: usize,
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        let ast = query_to_sql(&self.plan)?;
+        let ast = query_to_sql(&self.plan, self.executor.dialect())?;
         let query = format!("{ast}");
 
         self.executor.execute(query.as_str(), self.schema())

--- a/sources/sql/src/producer.rs
+++ b/sources/sql/src/producer.rs
@@ -17,13 +17,16 @@ use datafusion::logical_expr::expr::{
 };
 use datafusion::logical_expr::{Between, LogicalPlan, Operator};
 use datafusion::prelude::Expr;
+use datafusion::sql::sqlparser::dialect::{
+    Dialect, GenericDialect, PostgreSqlDialect, SQLiteDialect,
+};
 
 use crate::ast_builder::{
     BuilderError, QueryBuilder, RelationBuilder, SelectBuilder, TableRelationBuilder,
     TableWithJoinsBuilder,
 };
 
-pub fn query_to_sql(plan: &LogicalPlan, dialect: &str) -> Result<ast::Statement> {
+pub fn query_to_sql(plan: &LogicalPlan, dialect: Arc<dyn Dialect>) -> Result<ast::Statement> {
     match plan {
         LogicalPlan::Projection(_)
         | LogicalPlan::Filter(_)
@@ -87,7 +90,7 @@ fn select_to_sql(
     query: &mut QueryBuilder,
     select: &mut SelectBuilder,
     relation: &mut RelationBuilder,
-    dialect: &str,
+    dialect: Arc<dyn Dialect>,
 ) -> Result<()> {
     match plan {
         LogicalPlan::TableScan(scan) => {
@@ -104,18 +107,25 @@ fn select_to_sql(
             let items = p
                 .expr
                 .iter()
-                .map(|e| select_item_to_sql(e, p.input.schema(), 0, dialect).unwrap())
+                .map(|e| select_item_to_sql(e, p.input.schema(), 0, dialect.clone()).unwrap())
                 .collect::<Vec<_>>();
             select.projection(items);
 
-            select_to_sql(p.input.as_ref(), query, select, relation, dialect)
+            select_to_sql(p.input.as_ref(), query, select, relation, dialect.clone())
         }
         LogicalPlan::Filter(filter) => {
-            let filter_expr = expr_to_sql(&filter.predicate, filter.input.schema(), 0, dialect)?;
+            let filter_expr =
+                expr_to_sql(&filter.predicate, filter.input.schema(), 0, dialect.clone())?;
 
             select.selection(Some(filter_expr));
 
-            select_to_sql(filter.input.as_ref(), query, select, relation, dialect)
+            select_to_sql(
+                filter.input.as_ref(),
+                query,
+                select,
+                relation,
+                dialect.clone(),
+            )
         }
         LogicalPlan::Limit(limit) => {
             if let Some(fetch) = limit.fetch {
@@ -125,12 +135,29 @@ fn select_to_sql(
                 ))));
             }
 
-            select_to_sql(limit.input.as_ref(), query, select, relation, dialect)
+            select_to_sql(
+                limit.input.as_ref(),
+                query,
+                select,
+                relation,
+                dialect.clone(),
+            )
         }
         LogicalPlan::Sort(sort) => {
-            query.order_by(sort_to_sql(sort.expr.clone(), sort.input.schema(), 0, dialect)?);
+            query.order_by(sort_to_sql(
+                sort.expr.clone(),
+                sort.input.schema(),
+                0,
+                dialect.clone(),
+            )?);
 
-            select_to_sql(sort.input.as_ref(), query, select, relation, dialect)
+            select_to_sql(
+                sort.input.as_ref(),
+                query,
+                select,
+                relation,
+                dialect.clone(),
+            )
         }
         LogicalPlan::Aggregate(_agg) => {
             not_impl_err!("Unsupported operator: {plan:?}")
@@ -149,14 +176,24 @@ fn select_to_sql(
             // parse filter if exists
             let in_join_schema = join.left.schema().join(join.right.schema())?;
             let join_filter = match &join.filter {
-                Some(filter) => Some(expr_to_sql(filter, &Arc::new(in_join_schema), 0, dialect)?),
+                Some(filter) => Some(expr_to_sql(
+                    filter,
+                    &Arc::new(in_join_schema),
+                    0,
+                    dialect.clone(),
+                )?),
                 None => None,
             };
 
             // map join.on to `l.a = r.a AND l.b = r.b AND ...`
             let eq_op = ast::BinaryOperator::Eq;
-            let join_on =
-                join_conditions_to_sql(&join.on, eq_op, join.left.schema(), join.right.schema(), dialect)?;
+            let join_on = join_conditions_to_sql(
+                &join.on,
+                eq_op,
+                join.left.schema(),
+                join.right.schema(),
+                dialect.clone(),
+            )?;
 
             // Merge `join_on` and `join_filter`
             let join_expr = match (join_filter, join_on) {
@@ -172,8 +209,14 @@ fn select_to_sql(
 
             let mut right_relation = RelationBuilder::default();
 
-            select_to_sql(join.left.as_ref(), query, select, relation, dialect)?;
-            select_to_sql(join.right.as_ref(), query, select, &mut right_relation, dialect)?;
+            select_to_sql(join.left.as_ref(), query, select, relation, dialect.clone())?;
+            select_to_sql(
+                join.right.as_ref(),
+                query,
+                select,
+                &mut right_relation,
+                dialect.clone(),
+            )?;
 
             let ast_join = ast::Join {
                 relation: right_relation.build().map_err(builder_error_to_df)?,
@@ -187,9 +230,18 @@ fn select_to_sql(
         }
         LogicalPlan::SubqueryAlias(plan_alias) => {
             // Handle bottom-up to allocate relation
-            select_to_sql(plan_alias.input.as_ref(), query, select, relation, dialect)?;
+            select_to_sql(
+                plan_alias.input.as_ref(),
+                query,
+                select,
+                relation,
+                dialect.clone(),
+            )?;
 
-            relation.alias(Some(new_table_alias(plan_alias.alias.table().to_string(), dialect)));
+            relation.alias(Some(new_table_alias(
+                plan_alias.alias.table().to_string(),
+                dialect.clone(),
+            )));
 
             Ok(())
         }
@@ -208,26 +260,31 @@ fn select_item_to_sql(
     expr: &Expr,
     schema: &DFSchemaRef,
     col_ref_offset: usize,
-    dialect: &str,
+    dialect: Arc<dyn Dialect>,
 ) -> Result<ast::SelectItem> {
     match expr {
         Expr::Alias(Alias { expr, name, .. }) => {
-            let inner = expr_to_sql(expr, schema, col_ref_offset, dialect)?;
+            let inner = expr_to_sql(expr, schema, col_ref_offset, dialect.clone())?;
 
             Ok(ast::SelectItem::ExprWithAlias {
                 expr: inner,
-                alias: new_ident(name.to_string(), dialect),
+                alias: new_ident(name.to_string(), dialect.clone()),
             })
         }
         _ => {
-            let inner = expr_to_sql(expr, schema, col_ref_offset, dialect)?;
+            let inner = expr_to_sql(expr, schema, col_ref_offset, dialect.clone())?;
 
             Ok(ast::SelectItem::UnnamedExpr(inner))
         }
     }
 }
 
-fn expr_to_sql(expr: &Expr, _schema: &DFSchemaRef, _col_ref_offset: usize, dialect: &str) -> Result<SQLExpr> {
+fn expr_to_sql(
+    expr: &Expr,
+    _schema: &DFSchemaRef,
+    _col_ref_offset: usize,
+    dialect: Arc<dyn Dialect>,
+) -> Result<SQLExpr> {
     match expr {
         Expr::InList(InList {
             expr,
@@ -247,10 +304,10 @@ fn expr_to_sql(expr: &Expr, _schema: &DFSchemaRef, _col_ref_offset: usize, diale
         }) => {
             not_impl_err!("Unsupported expression: {expr:?}")
         }
-        Expr::Column(col) => col_to_sql(col, dialect),
+        Expr::Column(col) => col_to_sql(col, dialect.clone()),
         Expr::BinaryExpr(BinaryExpr { left, op, right }) => {
-            let l = expr_to_sql(left.as_ref(), _schema, 0, dialect)?;
-            let r = expr_to_sql(right.as_ref(), _schema, 0, dialect)?;
+            let l = expr_to_sql(left.as_ref(), _schema, 0, dialect.clone())?;
+            let r = expr_to_sql(right.as_ref(), _schema, 0, dialect.clone())?;
             let op = op_to_sql(op)?;
 
             Ok(binary_op_to_sql(l, r, op))
@@ -266,7 +323,9 @@ fn expr_to_sql(expr: &Expr, _schema: &DFSchemaRef, _col_ref_offset: usize, diale
             not_impl_err!("Unsupported expression: {expr:?}")
         }
         Expr::Literal(value) => Ok(ast::Expr::Value(scalar_to_sql(value)?)),
-        Expr::Alias(Alias { expr, name: _, .. }) => expr_to_sql(expr, _schema, _col_ref_offset, dialect),
+        Expr::Alias(Alias { expr, name: _, .. }) => {
+            expr_to_sql(expr, _schema, _col_ref_offset, dialect.clone())
+        }
         Expr::WindowFunction(WindowFunction {
             fun: _,
             args: _,
@@ -293,13 +352,13 @@ fn sort_to_sql(
     sort_exprs: Vec<Expr>,
     _schema: &DFSchemaRef,
     _col_ref_offset: usize,
-    dialect: &str,
+    dialect: Arc<dyn Dialect>,
 ) -> Result<Vec<OrderByExpr>> {
     sort_exprs
         .iter()
         .map(|expr: &Expr| match expr {
             Expr::Sort(sort_expr) => {
-                let col = expr_to_sql(&sort_expr.expr, _schema, _col_ref_offset, dialect)?;
+                let col = expr_to_sql(&sort_expr.expr, _schema, _col_ref_offset, dialect.clone())?;
                 Ok(OrderByExpr {
                     asc: Some(sort_expr.asc),
                     expr: col,
@@ -430,14 +489,14 @@ fn scalar_to_sql(v: &ScalarValue) -> Result<ast::Value> {
     }
 }
 
-fn col_to_sql(col: &Column, dialect: &str,) -> Result<ast::Expr> {
+fn col_to_sql(col: &Column, dialect: Arc<dyn Dialect>) -> Result<ast::Expr> {
     Ok(ast::Expr::CompoundIdentifier(
         [
             col.relation.as_ref().unwrap().table().to_string(),
             col.name.to_string(),
         ]
         .iter()
-        .map(|i| new_ident(i.to_string(), dialect))
+        .map(|i| new_ident(i.to_string(), dialect.clone()))
         .collect(),
     ))
 }
@@ -460,19 +519,19 @@ fn join_conditions_to_sql(
     eq_op: ast::BinaryOperator,
     left_schema: &DFSchemaRef,
     right_schema: &DFSchemaRef,
-    dialect: &str,
+    dialect: Arc<dyn Dialect>,
 ) -> Result<Option<SQLExpr>> {
     // Only support AND conjunction for each binary expression in join conditions
     let mut exprs: Vec<SQLExpr> = vec![];
     for (left, right) in join_conditions {
         // Parse left
-        let l = expr_to_sql(left, left_schema, 0, dialect)?;
+        let l = expr_to_sql(left, left_schema, 0, dialect.clone())?;
         // Parse right
         let r = expr_to_sql(
             right,
             right_schema,
             left_schema.fields().len(), // offset to return the correct index
-            dialect,
+            dialect.clone(),
         )?;
         // AND with existing expression
         exprs.push(binary_op_to_sql(l, r, eq_op.clone()));
@@ -493,21 +552,22 @@ pub fn binary_op_to_sql(lhs: SQLExpr, rhs: SQLExpr, op: ast::BinaryOperator) -> 
     }
 }
 
-fn new_table_alias(alias: String, dialect: &str) -> ast::TableAlias {
+fn new_table_alias(alias: String, dialect: Arc<dyn Dialect>) -> ast::TableAlias {
     ast::TableAlias {
-        name: new_ident(alias, dialect),
+        name: new_ident(alias, dialect.clone()),
         columns: Vec::new(),
     }
 }
 
-fn new_ident(str: String, dialect: &str) -> ast::Ident {
+fn new_ident(str: String, dialect: Arc<dyn Dialect>) -> ast::Ident {
     ast::Ident {
         value: str,
-        quote_style: match dialect {
-            "postgres" => Some('"'),
-            "sqlite"
-            | "flight" => Some('`'),
-            _ => todo!()
+        quote_style: if dialect.is::<PostgreSqlDialect>() {
+            Some('"')
+        } else if dialect.is::<SQLiteDialect>() || dialect.is::<GenericDialect>() {
+            Some('`')
+        } else {
+            todo!()
         },
     }
 }

--- a/sources/sql/src/producer.rs
+++ b/sources/sql/src/producer.rs
@@ -76,8 +76,7 @@ pub fn query_to_sql(plan: &LogicalPlan, dialect: &str) -> Result<ast::Statement>
         | LogicalPlan::Ddl(_)
         | LogicalPlan::Copy(_)
         | LogicalPlan::DescribeTable(_)
-        | LogicalPlan::Unnest(_)
-        | LogicalPlan::RecursiveQuery(_) => Err(DataFusionError::NotImplemented(
+        | LogicalPlan::Unnest(_) => Err(DataFusionError::NotImplemented(
             "Unsupported operator: {plan:?}".to_string(),
         )),
     }


### PR DESCRIPTION
Federation wasn’t working with the Postgres dialect and ConnectorX was crashing on an example using postgres, so this PR adds fixes for both of these issues.

The dialect parameter will allow future extensibility to other dialects for query generation.