### PR TITLE
feat: add schema to ast builder

### DIFF
--- a/sql-writer/src/lib.rs
+++ b/sql-writer/src/lib.rs
@@ -109,12 +109,12 @@ fn select_to_sql(
             if let Some(schema_name) = scan.table_name.schema() {
                 table_parts.push(new_ident(
                     schema_name.to_string(),
-                    dialect,
+                    dialect.clone(),
                 ));
             }
             table_parts.push(new_ident(
                 scan.table_name.table().to_string(),
-                dialect,
+                dialect.clone(),
             ));
 
             builder.name(ast::ObjectName(table_parts));

--- a/sql-writer/src/lib.rs
+++ b/sql-writer/src/lib.rs
@@ -105,10 +105,19 @@ fn select_to_sql(
     match plan {
         LogicalPlan::TableScan(scan) => {
             let mut builder = TableRelationBuilder::default();
-            builder.name(ast::ObjectName(vec![new_ident(
+            let mut table_parts = vec![];
+            if let Some(schema_name) = scan.table_name.schema() {
+                table_parts.push(new_ident(
+                    schema_name.to_string(),
+                    dialect,
+                ));
+            }
+            table_parts.push(new_ident(
                 scan.table_name.table().to_string(),
                 dialect,
-            )]));
+            ));
+
+            builder.name(ast::ObjectName(table_parts));
             relation.table(builder);
 
             Ok(())


### PR DESCRIPTION
SQL languages will typically have schemas, so add support for schema names to the table scan AST builder.