### PR TITLE
fix: adds more information when an `EXPLAIN <query>` is run on a federated source

### DIFF
--- a/datafusion-federation/src/plan_node.rs
+++ b/datafusion-federation/src/plan_node.rs
@@ -54,7 +54,7 @@ impl UserDefinedLogicalNodeCore for FederatedPlanNode {
     }
 
     fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Federated")
+        write!(f, "Federated\n {:?}", self.plan)
     }
 
     fn from_template(&self, exprs: &[Expr], inputs: &[LogicalPlan]) -> Self {

--- a/examples/examples/sqlite.rs
+++ b/examples/examples/sqlite.rs
@@ -44,8 +44,17 @@ async fn main() -> datafusion::error::Result<()> {
          JOIN Artist ar ON a.ArtistId = ar.ArtistId
          limit 10"#;
     let df = ctx.sql(query).await?;
+    df.show().await?;
 
-    df.show().await
+    // If the environment variable EXPLAIN is set, print the query plan
+    if std::env::var("EXPLAIN").is_ok() {
+        let explain_query = format!("EXPLAIN {query}");
+        let df = ctx.sql(explain_query.as_str()).await?;
+
+        df.show().await?;
+    }
+
+    Ok(())
 }
 
 fn overwrite_default_schema(state: &SessionState, schema: Arc<dyn SchemaProvider>) -> Result<()> {

--- a/sources/sql/src/lib.rs
+++ b/sources/sql/src/lib.rs
@@ -141,7 +141,15 @@ impl VirtualExecutionPlan {
 
 impl DisplayAs for VirtualExecutionPlan {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> std::fmt::Result {
-        write!(f, "VirtualExecutionPlan")
+        write!(f, "VirtualExecutionPlan");
+        let Ok(ast) = plan_to_sql(&self.plan) else {
+            return Ok(());
+        };
+        write!(f, " name={}", self.executor.name());
+        if let Some(ctx) = self.executor.compute_context() {
+            write!(f, " compute_context={ctx}");
+        }
+        write!(f, " sql={ast}")
     }
 }
 

--- a/sources/sql/src/lib.rs
+++ b/sources/sql/src/lib.rs
@@ -141,13 +141,13 @@ impl VirtualExecutionPlan {
 
 impl DisplayAs for VirtualExecutionPlan {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> std::fmt::Result {
-        write!(f, "VirtualExecutionPlan");
+        write!(f, "VirtualExecutionPlan")?;
         let Ok(ast) = plan_to_sql(&self.plan) else {
             return Ok(());
         };
-        write!(f, " name={}", self.executor.name());
+        write!(f, " name={}", self.executor.name())?;
         if let Some(ctx) = self.executor.compute_context() {
-            write!(f, " compute_context={ctx}");
+            write!(f, " compute_context={ctx}")?;
         }
         write!(f, " sql={ast}")
     }


### PR DESCRIPTION
I wanted an easy way to be able to quickly check what SQL is actually being sent to a remote SQLExecutor, as well as the logical plan that was being federated.

Ideally we could have more information about the compute context at the LogicalPlan level, but I'm not 100% sure what makes sense yet.

Sample output:
`EXPLAIN="true" cargo run --example sqlite`
```
+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan_type     | plan                                                                                                                                                                                                                                                                                                                                                                     |
+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| logical_plan  | Federated                                                                                                                                                                                                                                                                                                                                                                |
|               |  Limit: skip=0, fetch=10                                                                                                                                                                                                                                                                                                                                                 |
|               |   Projection: t.trackid, t.name AS trackname, a.title AS albumtitle, ar.name AS artistname                                                                                                                                                                                                                                                                               |
|               |     Inner Join:  Filter: a.artistid = ar.artistid                                                                                                                                                                                                                                                                                                                        |
|               |       Inner Join:  Filter: t.albumid = a.albumid                                                                                                                                                                                                                                                                                                                         |
|               |         SubqueryAlias: t                                                                                                                                                                                                                                                                                                                                                 |
|               |           TableScan: track                                                                                                                                                                                                                                                                                                                                               |
|               |         SubqueryAlias: a                                                                                                                                                                                                                                                                                                                                                 |
|               |           TableScan: album                                                                                                                                                                                                                                                                                                                                               |
|               |       SubqueryAlias: ar                                                                                                                                                                                                                                                                                                                                                  |
|               |         TableScan: artist                                                                                                                                                                                                                                                                                                                                                |
| physical_plan | VirtualExecutionPlan name=connector_x_executor compute_context=sqlite://./examples/examples/chinook.sqlite sql=SELECT "t"."trackid", "t"."name" AS "trackname", "a"."title" AS "albumtitle", "ar"."name" AS "artistname" FROM "track" AS "t" JOIN "album" AS "a" ON ("t"."albumid" = "a"."albumid") JOIN "artist" AS "ar" ON ("a"."artistid" = "ar"."artistid") LIMIT 10 |
|               |                                                                                                                                                                                                                                                                                                                                                                          |
+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```