### PR TITLE
update datafusion to 41

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,9 @@ resolver = "2"
 
 members = [
     "datafusion-federation",
-    "examples",
     "sources/sql",
     "sources/flight-sql",
 ]
-
-[patch.crates-io]
-# connectorx = { path = "../connector-x/connectorx" }
-# datafusion = { path = "../arrow-datafusion/datafusion/core" }
 
 [workspace.package]
 version = "0.1.3"
@@ -18,8 +13,7 @@ edition = "2021"
 license = "MIT"
 readme = "README.md"
 
-
 [workspace.dependencies]
-async-trait = "0.1.77"
-datafusion = "37.0.0"
-datafusion-substrait = "37.0.0"
+async-trait = "0.1.81"
+datafusion = "41.0.0"
+datafusion-substrait = "41.0.0"

--- a/datafusion-federation/src/lib.rs
+++ b/datafusion-federation/src/lib.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use datafusion::{
-    execution::context::{SessionContext, SessionState},
+    execution::session_state::{SessionState, SessionStateBuilder},
     optimizer::{optimizer::Optimizer, OptimizerRule},
 };
 
@@ -18,12 +18,11 @@ mod plan_node;
 pub use plan_node::*;
 
 pub fn default_session_state() -> SessionState {
-    let df_state = SessionContext::new().state();
-
     let rules = default_optimizer_rules();
-    df_state
+    SessionStateBuilder::new()
         .with_optimizer_rules(rules)
         .with_query_planner(Arc::new(FederatedQueryPlanner::new()))
+        .build()
 }
 
 pub fn default_optimizer_rules() -> Vec<Arc<dyn OptimizerRule + Send + Sync>> {

--- a/datafusion-federation/src/optimizer.rs
+++ b/datafusion-federation/src/optimizer.rs
@@ -258,7 +258,7 @@ impl FederationOptimizerRule {
             };
 
             // If this is the root plan node; federate the entire plan
-            let optimized = optimizer.optimize(plan, _config, |_, _| {})?;
+            let optimized = optimizer.optimize(plan.clone(), _config, |_, _| {})?;
             return Ok((Some(optimized), ScanResult::None));
         }
 
@@ -296,7 +296,7 @@ impl FederationOptimizerRule {
 
                 // Replace the input with the federated counterpart
                 let wrapped = wrap_projection(original_input)?;
-                let optimized = optimizer.optimize(&wrapped, _config, |_, _| {})?;
+                let optimized = optimizer.optimize(wrapped, _config, |_, _| {})?;
 
                 Ok(optimized)
             })
@@ -398,9 +398,9 @@ fn wrap_projection(plan: LogicalPlan) -> Result<LogicalPlan> {
         _ => {
             let expr = plan
                 .schema()
-                .fields()
+                .columns()
                 .iter()
-                .map(|f| Expr::Column(f.qualified_column()))
+                .map(|c| Expr::Column(c.clone()))
                 .collect::<Vec<Expr>>();
             Ok(LogicalPlan::Projection(Projection::try_new(
                 expr,

--- a/datafusion-federation/src/plan_node.rs
+++ b/datafusion-federation/src/plan_node.rs
@@ -65,6 +65,14 @@ impl UserDefinedLogicalNodeCore for FederatedPlanNode {
             planner: self.planner.clone(),
         }
     }
+
+    /// XXX should consider something else here ?
+    fn with_exprs_and_inputs(&self, _exprs: Vec<Expr>, _inputs: Vec<LogicalPlan>) -> Result<Self> {
+        Ok(Self {
+            plan: self.plan.clone(),
+            planner: self.planner.clone(),
+        })
+    }
 }
 
 #[derive(Default)]

--- a/datafusion-federation/src/table_provider.rs
+++ b/datafusion-federation/src/table_provider.rs
@@ -3,10 +3,10 @@ use std::{any::Any, sync::Arc};
 use async_trait::async_trait;
 use datafusion::{
     arrow::datatypes::SchemaRef,
+    catalog::Session,
     common::Constraints,
     datasource::TableProvider,
     error::{DataFusionError, Result},
-    execution::context::SessionState,
     logical_expr::{Expr, LogicalPlan, TableProviderFilterPushDown, TableSource, TableType},
     physical_plan::ExecutionPlan,
 };
@@ -106,7 +106,7 @@ impl TableProvider for FederatedTableProviderAdaptor {
     // with a virtual TableProvider that provides federation for a sub-plan.
     async fn scan(
         &self,
-        state: &SessionState,
+        state: &dyn Session,
         projection: Option<&Vec<usize>>,
         filters: &[Expr],
         limit: Option<usize>,
@@ -122,7 +122,7 @@ impl TableProvider for FederatedTableProviderAdaptor {
 
     async fn insert_into(
         &self,
-        _state: &SessionState,
+        _state: &dyn Session,
         input: Arc<dyn ExecutionPlan>,
         overwrite: bool,
     ) -> Result<Arc<dyn ExecutionPlan>> {

--- a/sources/flight-sql/Cargo.toml
+++ b/sources/flight-sql/Cargo.toml
@@ -3,7 +3,6 @@ name = "datafusion-federation-flight-sql"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-readme.workspace = true
 
 [lib]
 name = "datafusion_federation_flight_sql"
@@ -13,11 +12,14 @@ path = "src/lib.rs"
 async-trait.workspace = true
 datafusion.workspace = true
 datafusion-substrait.workspace = true
+
+# XXX use the release verion on crates.io 
 datafusion-federation.path = "../../datafusion-federation"
 datafusion-federation-sql.path = "../sql"
+
 futures = "0.3.30"
-tonic = {version="0.11.0", features=["tls"] }
-prost = "0.12.3"
-arrow = "51.0.0"
-arrow-flight = { version = "51.0.0", features = ["flight-sql-experimental"] }
-log = "0.4.20"
+tonic = {version="0.12.0", features=["tls"] }
+prost = "0.13"
+arrow = "52.0.0"
+arrow-flight = { version = "52.0.0", features = ["flight-sql-experimental"] }
+log = "0.4.22"

--- a/sources/sql/Cargo.toml
+++ b/sources/sql/Cargo.toml
@@ -3,7 +3,6 @@ name = "datafusion-federation-sql"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-readme.workspace = true
 
 [lib]
 name = "datafusion_federation_sql"
@@ -11,14 +10,11 @@ path = "src/lib.rs"
 
 [dependencies]
 async-trait.workspace = true
-# connectorx = { version = "0.3.2", features = ["src_sqlite"] }
-# https://github.com/sfu-db/connector-x/pull/555
-connectorx = { git = "https://github.com/devinjdangelo/connector-x.git", features = [
-    "dst_arrow",
-    "src_sqlite"
-] }
 datafusion.workspace = true
+
+# XXX use the release verion on crates.io 
 datafusion-federation.path = "../../datafusion-federation"
-# derive_builder = "0.13.0"
+
+connectorx = { version = "0.3.3" , features = ["dst_arrow", "src_sqlite"] }
 futures = "0.3.30"
-tokio = "1.35.1"
+tokio = "1.39"

--- a/sources/sql/src/connectorx/executor.rs
+++ b/sources/sql/src/connectorx/executor.rs
@@ -53,6 +53,7 @@ impl SQLExecutor for CXExecutor {
     fn compute_context(&self) -> Option<String> {
         Some(self.context.clone())
     }
+
     fn execute(&self, sql: &str, schema: SchemaRef) -> Result<SendableRecordBatchStream> {
         let conn = self.conn.clone();
         let query: CXQuery = sql.into();

--- a/sources/sql/src/lib.rs
+++ b/sources/sql/src/lib.rs
@@ -162,6 +162,10 @@ impl DisplayAs for VirtualExecutionPlan {
 }
 
 impl ExecutionPlan for VirtualExecutionPlan {
+    fn name(&self) -> &str {
+        "sql_federation_exec"
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -170,7 +174,7 @@ impl ExecutionPlan for VirtualExecutionPlan {
         self.schema()
     }
 
-    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
         vec![]
     }
 

--- a/sources/sql/src/schema.rs
+++ b/sources/sql/src/schema.rs
@@ -2,8 +2,7 @@ use async_trait::async_trait;
 
 use datafusion::logical_expr::{TableSource, TableType};
 use datafusion::{
-    arrow::datatypes::SchemaRef, catalog::schema::SchemaProvider, datasource::TableProvider,
-    error::Result,
+    arrow::datatypes::SchemaRef, catalog::SchemaProvider, datasource::TableProvider, error::Result,
 };
 use futures::future::join_all;
 use std::{any::Any, sync::Arc};


### PR DESCRIPTION
Hello,

This PR updates the `datafusion` version to 41 and modifies the `datafusion-federation-sql` crate to use the `connectorx` crate from crates.io instead of pulling it directly from the Git repository. It also updates other dependencies.

Please note that this PR is still a work in progress (WIP), as there is currently a version mismatch between the `arrow` crate used by `datafusion` and `connectorx`.