### PR TITLE
upgrade datafusion & arrow

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,45 @@
+## https://taplo.tamasfe.dev/configuration/file.html
+
+include = ["**/Cargo.toml"]
+
+[formatting]
+# Align consecutive entries vertically.
+align_entries = false
+# Append trailing commas for multi-line arrays.
+array_trailing_comma = true
+# Expand arrays to multiple lines that exceed the maximum column width.
+array_auto_expand = true
+# Collapse arrays that don't exceed the maximum column width and don't contain comments.
+array_auto_collapse = false
+# Omit white space padding from single-line arrays
+compact_arrays = true
+# Omit white space padding from the start and end of inline tables.
+compact_inline_tables = false
+# Maximum column width in characters, affects array expansion and collapse, this doesn't take whitespace into account.
+# Note that this is not set in stone, and works on a best-effort basis.
+column_width = 120
+# Indent based on tables and arrays of tables and their subtables, subtables out of order are not indented.
+indent_tables = false
+# The substring that is used for indentation, should be tabs or spaces (but technically can be anything).
+indent_string = '    '
+# Add trailing newline at the end of the file if not present.
+trailing_newline = true
+# Alphabetically reorder keys that are not separated by empty lines.
+reorder_keys = false
+# Maximum amount of allowed consecutive blank lines. This does not affect the whitespace at the end of the document, as it is always stripped.
+allowed_blank_lines = 1
+# Use CRLF for line endings.
+crlf = false
+
+[[rule]]
+keys = [
+    "build-dependencies",
+    "dependencies",
+    "dev-dependencies",
+    "workspace.dependencies",
+]
+formatting = { reorder_keys = true }
+
+[[rule]]
+keys = ["package"]
+formatting = { reorder_keys = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,19 +17,11 @@ repository = "https://github.com/datafusion-contrib/datafusion-federation"
 [workspace.dependencies]
 datafusion-federation = { path = "datafusion-federation", version = "0.2.1" }
 
-arrow-array = "53.0.0"
-arrow-cast = "53.0.0"
 arrow-flight = { version = "53.0.0", features = ["flight-sql-experimental"] }
-arrow-ipc = "53.0.0"
-arrow-json = "53.0.0"
 arrow-schema = "53.0.0"
-datafusion = "42.0.0"
-datafusion-catalog = "42.0.0"
+datafusion = { version = "42.0.0", default-features = false }
 datafusion-common = "42.0.0"
 datafusion-execution = "42.0.0"
-datafusion-expr = "42.0.0"
-datafusion-optimizer = "42.0.0"
-datafusion-physical-expr = "42.0.0"
 datafusion-physical-plan = "42.0.0"
 datafusion-sql = "42.0.0"
 datafusion-substrait = "42.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,12 @@ readme = "README.md"
 repository = "https://github.com/datafusion-contrib/datafusion-federation"
 
 [workspace.dependencies]
-async-trait = "0.1.81"
+arrow = "53.0.0"
+arrow-flight = { version = "53.0.0", features = ["flight-sql-experimental"] }
+arrow-json = "53.0.0"
 async-stream = "0.3.5"
+async-trait = "0.1.81"
+datafusion = "42.0.0"
+datafusion-federation = { path = "datafusion-federation", version = "0.2.1" }
+datafusion-substrait = "42.0.0"
 futures = "0.3.30"
-datafusion = "41.0.0"
-datafusion-substrait = "41.0.0"
-arrow-json = "52.2.0"
-datafusion-federation = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,25 @@ readme = "README.md"
 repository = "https://github.com/datafusion-contrib/datafusion-federation"
 
 [workspace.dependencies]
-arrow = "53.0.0"
+datafusion-federation = { path = "datafusion-federation", version = "0.2.1" }
+
+arrow-array = "53.0.0"
+arrow-cast = "53.0.0"
 arrow-flight = { version = "53.0.0", features = ["flight-sql-experimental"] }
+arrow-ipc = "53.0.0"
 arrow-json = "53.0.0"
+arrow-schema = "53.0.0"
+datafusion = "42.0.0"
+datafusion-catalog = "42.0.0"
+datafusion-common = "42.0.0"
+datafusion-execution = "42.0.0"
+datafusion-expr = "42.0.0"
+datafusion-optimizer = "42.0.0"
+datafusion-physical-expr = "42.0.0"
+datafusion-physical-plan = "42.0.0"
+datafusion-sql = "42.0.0"
+datafusion-substrait = "42.0.0"
+
 async-stream = "0.3.5"
 async-trait = "0.1.81"
-datafusion = "42.0.0"
-datafusion-federation = { path = "datafusion-federation", version = "0.2.1" }
-datafusion-substrait = "42.0.0"
 futures = "0.3.30"

--- a/datafusion-federation/Cargo.toml
+++ b/datafusion-federation/Cargo.toml
@@ -21,10 +21,21 @@ no-default-features = true
 sql = []
 
 [dependencies]
+arrow-array.workspace = true
+arrow-cast.workspace = true
 arrow-json.workspace = true
+arrow-schema.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
 datafusion.workspace = true
+datafusion-catalog.workspace = true
+datafusion-common.workspace = true
+datafusion-execution.workspace = true
+datafusion-expr.workspace = true
+datafusion-optimizer.workspace = true
+datafusion-physical-expr.workspace = true
+datafusion-physical-plan.workspace = true
+datafusion-sql.workspace = true
 futures.workspace = true
 
 [dev-dependencies]

--- a/datafusion-federation/Cargo.toml
+++ b/datafusion-federation/Cargo.toml
@@ -21,17 +21,16 @@ no-default-features = true
 sql = []
 
 [dependencies]
-futures.workspace = true
+arrow-json.workspace = true
+async-stream.workspace = true
 async-trait.workspace = true
 datafusion.workspace = true
-async-stream.workspace = true
-arrow-json.workspace = true
-
+futures.workspace = true
 
 [dev-dependencies]
 tokio = { version = "1.39.3", features = ["full"] }
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
 [[example]]
 name = "df-csv"

--- a/datafusion-federation/Cargo.toml
+++ b/datafusion-federation/Cargo.toml
@@ -21,21 +21,9 @@ no-default-features = true
 sql = []
 
 [dependencies]
-arrow-array.workspace = true
-arrow-cast.workspace = true
-arrow-json.workspace = true
-arrow-schema.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
 datafusion.workspace = true
-datafusion-catalog.workspace = true
-datafusion-common.workspace = true
-datafusion-execution.workspace = true
-datafusion-expr.workspace = true
-datafusion-optimizer.workspace = true
-datafusion-physical-expr.workspace = true
-datafusion-physical-plan.workspace = true
-datafusion-sql.workspace = true
 futures.workspace = true
 
 [dev-dependencies]

--- a/datafusion-federation/examples/df-csv.rs
+++ b/datafusion-federation/examples/df-csv.rs
@@ -1,18 +1,17 @@
 use std::sync::Arc;
 
+use arrow_schema::SchemaRef;
 use async_trait::async_trait;
 use datafusion::{
-    arrow::datatypes::SchemaRef,
-    catalog::SchemaProvider,
-    error::{DataFusionError, Result},
-    execution::{
-        context::{SessionContext, SessionState},
-        options::CsvReadOptions,
-    },
-    physical_plan::{stream::RecordBatchStreamAdapter, SendableRecordBatchStream},
-    sql::unparser::dialect::{DefaultDialect, Dialect},
+    execution::SessionState,
+    prelude::{CsvReadOptions, SessionContext},
 };
+use datafusion_catalog::SchemaProvider;
+use datafusion_common::{DataFusionError, Result};
+use datafusion_execution::SendableRecordBatchStream;
 use datafusion_federation::sql::{SQLExecutor, SQLFederationProvider, SQLSchemaProvider};
+use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion_sql::unparser::dialect::{DefaultDialect, Dialect};
 use futures::TryStreamExt;
 
 const CSV_PATH: &str = "./examples/test.csv";

--- a/datafusion-federation/examples/df-csv.rs
+++ b/datafusion-federation/examples/df-csv.rs
@@ -1,17 +1,16 @@
 use std::sync::Arc;
 
-use arrow_schema::SchemaRef;
 use async_trait::async_trait;
 use datafusion::{
-    execution::SessionState,
+    arrow::datatypes::SchemaRef,
+    catalog::SchemaProvider,
+    common::{DataFusionError, Result},
+    execution::{SendableRecordBatchStream, SessionState},
+    physical_plan::stream::RecordBatchStreamAdapter,
     prelude::{CsvReadOptions, SessionContext},
+    sql::unparser::dialect::{DefaultDialect, Dialect},
 };
-use datafusion_catalog::SchemaProvider;
-use datafusion_common::{DataFusionError, Result};
-use datafusion_execution::SendableRecordBatchStream;
 use datafusion_federation::sql::{SQLExecutor, SQLFederationProvider, SQLSchemaProvider};
-use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
-use datafusion_sql::unparser::dialect::{DefaultDialect, Dialect};
 use futures::TryStreamExt;
 
 const CSV_PATH: &str = "./examples/test.csv";

--- a/datafusion-federation/src/lib.rs
+++ b/datafusion-federation/src/lib.rs
@@ -10,8 +10,10 @@ use std::{
     sync::Arc,
 };
 
-use datafusion::execution::{SessionState, SessionStateBuilder};
-use datafusion_optimizer::{Optimizer, OptimizerRule};
+use datafusion::{
+    execution::{SessionState, SessionStateBuilder},
+    optimizer::{Optimizer, OptimizerRule},
+};
 pub use optimizer::{get_table_source, FederationOptimizerRule};
 pub use plan_node::{
     FederatedPlanNode, FederatedPlanner, FederatedQueryPlanner, FederationPlanner,

--- a/datafusion-federation/src/lib.rs
+++ b/datafusion-federation/src/lib.rs
@@ -10,11 +10,8 @@ use std::{
     sync::Arc,
 };
 
-use datafusion::{
-    execution::session_state::{SessionState, SessionStateBuilder},
-    optimizer::{optimizer::Optimizer, OptimizerRule},
-};
-
+use datafusion::execution::{SessionState, SessionStateBuilder};
+use datafusion_optimizer::{Optimizer, OptimizerRule};
 pub use optimizer::{get_table_source, FederationOptimizerRule};
 pub use plan_node::{
     FederatedPlanNode, FederatedPlanner, FederatedQueryPlanner, FederationPlanner,

--- a/datafusion-federation/src/optimizer.rs
+++ b/datafusion-federation/src/optimizer.rs
@@ -1,13 +1,15 @@
 use std::sync::Arc;
 
-use datafusion::datasource::source_as_provider;
-use datafusion_common::{
-    not_impl_err,
-    tree_node::{Transformed, TreeNode, TreeNodeRecursion},
-    Result,
+use datafusion::{
+    common::{
+        not_impl_err,
+        tree_node::{Transformed, TreeNode, TreeNodeRecursion},
+        Result,
+    },
+    datasource::source_as_provider,
+    logical_expr::{Expr, Extension, LogicalPlan, Projection, TableScan, TableSource},
+    optimizer::{Optimizer, OptimizerConfig, OptimizerRule},
 };
-use datafusion_expr::{Expr, Extension, LogicalPlan, Projection, TableScan, TableSource};
-use datafusion_optimizer::{Optimizer, OptimizerConfig, OptimizerRule};
 
 use crate::{
     FederatedTableProviderAdaptor, FederatedTableSource, FederationProvider, FederationProviderRef,

--- a/datafusion-federation/src/optimizer.rs
+++ b/datafusion-federation/src/optimizer.rs
@@ -1,15 +1,13 @@
 use std::sync::Arc;
 
-use datafusion::common::not_impl_err;
-use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
-use datafusion::logical_expr::Extension;
-use datafusion::optimizer::optimizer::Optimizer;
-use datafusion::optimizer::{OptimizerConfig, OptimizerRule};
-use datafusion::{
-    datasource::source_as_provider,
-    error::Result,
-    logical_expr::{Expr, LogicalPlan, Projection, TableScan, TableSource},
+use datafusion::datasource::source_as_provider;
+use datafusion_common::{
+    not_impl_err,
+    tree_node::{Transformed, TreeNode, TreeNodeRecursion},
+    Result,
 };
+use datafusion_expr::{Expr, Extension, LogicalPlan, Projection, TableScan, TableSource};
+use datafusion_optimizer::{Optimizer, OptimizerConfig, OptimizerRule};
 
 use crate::{
     FederatedTableProviderAdaptor, FederatedTableSource, FederationProvider, FederationProviderRef,

--- a/datafusion-federation/src/plan_node.rs
+++ b/datafusion-federation/src/plan_node.rs
@@ -7,13 +7,12 @@ use std::{
 
 use async_trait::async_trait;
 use datafusion::{
-    common::DFSchemaRef,
-    error::{DataFusionError, Result},
-    execution::context::{QueryPlanner, SessionState},
-    logical_expr::{Expr, LogicalPlan, UserDefinedLogicalNode, UserDefinedLogicalNodeCore},
-    physical_plan::ExecutionPlan,
+    execution::{context::QueryPlanner, SessionState},
     physical_planner::{DefaultPhysicalPlanner, ExtensionPlanner, PhysicalPlanner},
 };
+use datafusion_common::{DFSchemaRef, DataFusionError, Result};
+use datafusion_expr::{Expr, LogicalPlan, UserDefinedLogicalNode, UserDefinedLogicalNodeCore};
+use datafusion_physical_plan::ExecutionPlan;
 
 pub struct FederatedPlanNode {
     plan: LogicalPlan,

--- a/datafusion-federation/src/plan_node.rs
+++ b/datafusion-federation/src/plan_node.rs
@@ -7,12 +7,12 @@ use std::{
 
 use async_trait::async_trait;
 use datafusion::{
+    common::{DFSchemaRef, DataFusionError, Result},
     execution::{context::QueryPlanner, SessionState},
+    logical_expr::{Expr, LogicalPlan, UserDefinedLogicalNode, UserDefinedLogicalNodeCore},
+    physical_plan::ExecutionPlan,
     physical_planner::{DefaultPhysicalPlanner, ExtensionPlanner, PhysicalPlanner},
 };
-use datafusion_common::{DFSchemaRef, DataFusionError, Result};
-use datafusion_expr::{Expr, LogicalPlan, UserDefinedLogicalNode, UserDefinedLogicalNodeCore};
-use datafusion_physical_plan::ExecutionPlan;
 
 pub struct FederatedPlanNode {
     plan: LogicalPlan,

--- a/datafusion-federation/src/schema_cast.rs
+++ b/datafusion-federation/src/schema_cast.rs
@@ -1,10 +1,10 @@
+use arrow_schema::SchemaRef;
 use async_stream::stream;
-use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::error::{DataFusionError, Result};
-use datafusion::execution::{SendableRecordBatchStream, TaskContext};
-use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
-use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+use datafusion_common::{DataFusionError, Result};
+use datafusion_execution::{SendableRecordBatchStream, TaskContext};
+use datafusion_physical_plan::{
+    stream::RecordBatchStreamAdapter, DisplayAs, DisplayFormatType, ExecutionPlan,
+    ExecutionPlanProperties, PlanProperties,
 };
 use futures::StreamExt;
 use std::any::Any;

--- a/datafusion-federation/src/schema_cast.rs
+++ b/datafusion-federation/src/schema_cast.rs
@@ -1,10 +1,12 @@
-use arrow_schema::SchemaRef;
 use async_stream::stream;
-use datafusion_common::{DataFusionError, Result};
-use datafusion_execution::{SendableRecordBatchStream, TaskContext};
-use datafusion_physical_plan::{
-    stream::RecordBatchStreamAdapter, DisplayAs, DisplayFormatType, ExecutionPlan,
-    ExecutionPlanProperties, PlanProperties,
+use datafusion::{
+    arrow::datatypes::SchemaRef,
+    common::{DataFusionError, Result},
+    execution::{SendableRecordBatchStream, TaskContext},
+    physical_plan::{
+        stream::RecordBatchStreamAdapter, DisplayAs, DisplayFormatType, ExecutionPlan,
+        ExecutionPlanProperties, PlanProperties,
+    },
 };
 use futures::StreamExt;
 use std::any::Any;

--- a/datafusion-federation/src/schema_cast/intervals_cast.rs
+++ b/datafusion-federation/src/schema_cast/intervals_cast.rs
@@ -1,12 +1,11 @@
-use datafusion::arrow::{
-    array::{
-        Array, ArrayRef, IntervalDayTimeBuilder, IntervalMonthDayNanoArray,
-        IntervalYearMonthBuilder,
-    },
-    datatypes::{IntervalDayTimeType, IntervalYearMonthType},
-    error::ArrowError,
-};
 use std::sync::Arc;
+
+use arrow_array::{
+    builder::{IntervalDayTimeBuilder, IntervalYearMonthBuilder},
+    types::{IntervalDayTimeType, IntervalYearMonthType},
+    Array, ArrayRef, IntervalMonthDayNanoArray,
+};
+use arrow_schema::ArrowError;
 
 pub(crate) fn cast_interval_monthdaynano_to_yearmonth(
     interval_monthdaynano_array: &dyn Array,
@@ -76,16 +75,14 @@ pub(crate) fn cast_interval_monthdaynano_to_daytime(
 
 #[cfg(test)]
 mod test {
-    use datafusion::arrow::{
-        array::{IntervalDayTimeArray, IntervalYearMonthArray, RecordBatch},
-        datatypes::{
-            DataType, Field, IntervalDayTime, IntervalMonthDayNano, IntervalUnit, Schema, SchemaRef,
-        },
-    };
-
+    use super::*;
     use crate::schema_cast::record_convert::try_cast_to;
 
-    use super::*;
+    use arrow_array::{
+        types::{IntervalDayTime, IntervalMonthDayNano},
+        IntervalDayTimeArray, IntervalYearMonthArray, RecordBatch,
+    };
+    use arrow_schema::{DataType, Field, IntervalUnit, Schema, SchemaRef};
 
     fn input_schema() -> SchemaRef {
         Arc::new(Schema::new(vec![

--- a/datafusion-federation/src/schema_cast/intervals_cast.rs
+++ b/datafusion-federation/src/schema_cast/intervals_cast.rs
@@ -1,11 +1,13 @@
 use std::sync::Arc;
 
-use arrow_array::{
-    builder::{IntervalDayTimeBuilder, IntervalYearMonthBuilder},
-    types::{IntervalDayTimeType, IntervalYearMonthType},
-    Array, ArrayRef, IntervalMonthDayNanoArray,
+use datafusion::arrow::{
+    array::{
+        Array, ArrayRef, IntervalDayTimeBuilder, IntervalMonthDayNanoArray,
+        IntervalYearMonthBuilder,
+    },
+    datatypes::{IntervalDayTimeType, IntervalYearMonthType},
+    error::ArrowError,
 };
-use arrow_schema::ArrowError;
 
 pub(crate) fn cast_interval_monthdaynano_to_yearmonth(
     interval_monthdaynano_array: &dyn Array,
@@ -78,11 +80,12 @@ mod test {
     use super::*;
     use crate::schema_cast::record_convert::try_cast_to;
 
-    use arrow_array::{
-        types::{IntervalDayTime, IntervalMonthDayNano},
-        IntervalDayTimeArray, IntervalYearMonthArray, RecordBatch,
+    use datafusion::arrow::{
+        array::{IntervalDayTimeArray, IntervalYearMonthArray, RecordBatch},
+        datatypes::{
+            DataType, Field, IntervalDayTime, IntervalMonthDayNano, IntervalUnit, Schema, SchemaRef,
+        },
     };
-    use arrow_schema::{DataType, Field, IntervalUnit, Schema, SchemaRef};
 
     fn input_schema() -> SchemaRef {
         Arc::new(Schema::new(vec![

--- a/datafusion-federation/src/schema_cast/lists_cast.rs
+++ b/datafusion-federation/src/schema_cast/lists_cast.rs
@@ -1,14 +1,14 @@
-use arrow_array::{
-    builder::{
-        BooleanBuilder, FixedSizeListBuilder, Float32Builder, Float64Builder, Int16Builder,
-        Int32Builder, Int64Builder, Int8Builder, LargeListBuilder, LargeStringBuilder, ListBuilder,
-        StringBuilder,
+use datafusion::arrow::{
+    array::{
+        Array, ArrayRef, BooleanArray, BooleanBuilder, FixedSizeListBuilder, Float32Array,
+        Float32Builder, Float64Array, Float64Builder, Int16Array, Int16Builder, Int32Array,
+        Int32Builder, Int64Array, Int64Builder, Int8Array, Int8Builder, LargeListBuilder,
+        LargeStringArray, LargeStringBuilder, ListArray, ListBuilder, StringArray, StringBuilder,
     },
-    Array, ArrayRef, BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array,
-    Int8Array, LargeStringArray, ListArray, StringArray,
+    datatypes::{DataType, Field, FieldRef},
+    error::ArrowError,
+    json::ReaderBuilder,
 };
-use arrow_json::ReaderBuilder;
-use arrow_schema::{ArrowError, DataType, Field, FieldRef};
 use std::sync::Arc;
 
 pub type Result<T, E = crate::schema_cast::record_convert::Error> = std::result::Result<T, E>;
@@ -520,8 +520,10 @@ mod test {
     use super::*;
     use crate::schema_cast::record_convert::try_cast_to;
 
-    use arrow_array::RecordBatch;
-    use arrow_schema::{Schema, SchemaRef};
+    use datafusion::arrow::{
+        array::RecordBatch,
+        datatypes::{Schema, SchemaRef},
+    };
 
     fn input_schema() -> SchemaRef {
         Arc::new(Schema::new(vec![

--- a/datafusion-federation/src/schema_cast/lists_cast.rs
+++ b/datafusion-federation/src/schema_cast/lists_cast.rs
@@ -1,14 +1,14 @@
-use arrow_json::ReaderBuilder;
-use datafusion::arrow::{
-    array::{
-        Array, ArrayRef, BooleanArray, BooleanBuilder, FixedSizeListBuilder, Float32Array,
-        Float32Builder, Float64Array, Float64Builder, Int16Array, Int16Builder, Int32Array,
-        Int32Builder, Int64Array, Int64Builder, Int8Array, Int8Builder, LargeListBuilder,
-        LargeStringArray, LargeStringBuilder, ListArray, ListBuilder, StringArray, StringBuilder,
+use arrow_array::{
+    builder::{
+        BooleanBuilder, FixedSizeListBuilder, Float32Builder, Float64Builder, Int16Builder,
+        Int32Builder, Int64Builder, Int8Builder, LargeListBuilder, LargeStringBuilder, ListBuilder,
+        StringBuilder,
     },
-    datatypes::{DataType, Field, FieldRef},
-    error::ArrowError,
+    Array, ArrayRef, BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array,
+    Int8Array, LargeStringArray, ListArray, StringArray,
 };
+use arrow_json::ReaderBuilder;
+use arrow_schema::{ArrowError, DataType, Field, FieldRef};
 use std::sync::Arc;
 
 pub type Result<T, E = crate::schema_cast::record_convert::Error> = std::result::Result<T, E>;
@@ -517,14 +517,11 @@ pub(crate) fn cast_string_to_fixed_size_list(
 
 #[cfg(test)]
 mod test {
-    use datafusion::arrow::{
-        array::{RecordBatch, StringArray},
-        datatypes::{DataType, Field, Schema, SchemaRef},
-    };
-
+    use super::*;
     use crate::schema_cast::record_convert::try_cast_to;
 
-    use super::*;
+    use arrow_array::RecordBatch;
+    use arrow_schema::{Schema, SchemaRef};
 
     fn input_schema() -> SchemaRef {
         Arc::new(Schema::new(vec![

--- a/datafusion-federation/src/schema_cast/record_convert.rs
+++ b/datafusion-federation/src/schema_cast/record_convert.rs
@@ -1,8 +1,11 @@
 use std::sync::Arc;
 
-use arrow_array::{Array, RecordBatch};
-use arrow_cast::cast;
-use arrow_schema::{ArrowError, DataType, IntervalUnit, SchemaRef};
+use datafusion::arrow::{
+    array::{Array, RecordBatch},
+    compute::cast,
+    datatypes::{DataType, IntervalUnit, SchemaRef},
+    error::ArrowError,
+};
 
 use super::{
     intervals_cast::{
@@ -105,8 +108,10 @@ pub fn try_cast_to(record_batch: RecordBatch, expected_schema: SchemaRef) -> Res
 mod test {
     use super::*;
 
-    use arrow_array::{Int32Array, StringArray};
-    use arrow_schema::{Field, Schema, TimeUnit};
+    use datafusion::arrow::{
+        array::{Int32Array, StringArray},
+        datatypes::{Field, Schema, TimeUnit},
+    };
 
     fn schema() -> SchemaRef {
         Arc::new(Schema::new(vec![

--- a/datafusion-federation/src/schema_cast/record_convert.rs
+++ b/datafusion-federation/src/schema_cast/record_convert.rs
@@ -1,9 +1,8 @@
-use datafusion::arrow::{
-    array::{Array, RecordBatch},
-    compute::cast,
-    datatypes::{DataType, IntervalUnit, SchemaRef},
-};
 use std::sync::Arc;
+
+use arrow_array::{Array, RecordBatch};
+use arrow_cast::cast;
+use arrow_schema::{ArrowError, DataType, IntervalUnit, SchemaRef};
 
 use super::{
     intervals_cast::{
@@ -17,14 +16,9 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug)]
 pub enum Error {
-    UnableToConvertRecordBatch {
-        source: datafusion::arrow::error::ArrowError,
-    },
+    UnableToConvertRecordBatch { source: ArrowError },
 
-    UnexpectedNumberOfColumns {
-        expected: usize,
-        found: usize,
-    },
+    UnexpectedNumberOfColumns { expected: usize, found: usize },
 }
 
 impl std::error::Error for Error {}
@@ -109,12 +103,10 @@ pub fn try_cast_to(record_batch: RecordBatch, expected_schema: SchemaRef) -> Res
 
 #[cfg(test)]
 mod test {
-    use datafusion::arrow::{
-        array::{Int32Array, StringArray},
-        datatypes::{DataType, Field, Schema, TimeUnit},
-    };
-
     use super::*;
+
+    use arrow_array::{Int32Array, StringArray};
+    use arrow_schema::{Field, Schema, TimeUnit};
 
     fn schema() -> SchemaRef {
         Arc::new(Schema::new(vec![

--- a/datafusion-federation/src/schema_cast/struct_cast.rs
+++ b/datafusion-federation/src/schema_cast/struct_cast.rs
@@ -1,6 +1,9 @@
-use arrow_array::{Array, ArrayRef, StringArray};
-use arrow_json::ReaderBuilder;
-use arrow_schema::{ArrowError, Field};
+use datafusion::arrow::{
+    array::{Array, ArrayRef, StringArray},
+    datatypes::Field,
+    error::ArrowError,
+    json::ReaderBuilder,
+};
 use std::sync::Arc;
 
 pub type Result<T, E = crate::schema_cast::record_convert::Error> = std::result::Result<T, E>;
@@ -55,11 +58,10 @@ mod test {
     use super::*;
     use crate::schema_cast::record_convert::try_cast_to;
 
-    use arrow_array::{
-        builder::{Int32Builder, StringBuilder, StructBuilder},
-        RecordBatch,
+    use datafusion::arrow::{
+        array::{Int32Builder, RecordBatch, StringBuilder, StructBuilder},
+        datatypes::{DataType, Schema, SchemaRef},
     };
-    use arrow_schema::{DataType, Schema, SchemaRef};
 
     fn input_schema() -> SchemaRef {
         Arc::new(Schema::new(vec![Field::new(

--- a/datafusion-federation/src/schema_cast/struct_cast.rs
+++ b/datafusion-federation/src/schema_cast/struct_cast.rs
@@ -1,9 +1,6 @@
+use arrow_array::{Array, ArrayRef, StringArray};
 use arrow_json::ReaderBuilder;
-use datafusion::arrow::{
-    array::{Array, ArrayRef, StringArray},
-    datatypes::Field,
-    error::ArrowError,
-};
+use arrow_schema::{ArrowError, Field};
 use std::sync::Arc;
 
 pub type Result<T, E = crate::schema_cast::record_convert::Error> = std::result::Result<T, E>;
@@ -55,14 +52,14 @@ pub(crate) fn cast_string_to_struct(
 
 #[cfg(test)]
 mod test {
-    use datafusion::arrow::{
-        array::{Int32Builder, RecordBatch, StringArray, StringBuilder, StructBuilder},
-        datatypes::{DataType, Field, Schema, SchemaRef},
-    };
-
+    use super::*;
     use crate::schema_cast::record_convert::try_cast_to;
 
-    use super::*;
+    use arrow_array::{
+        builder::{Int32Builder, StringBuilder, StructBuilder},
+        RecordBatch,
+    };
+    use arrow_schema::{DataType, Schema, SchemaRef};
 
     fn input_schema() -> SchemaRef {
         Arc::new(Schema::new(vec![Field::new(

--- a/datafusion-federation/src/sql/executor.rs
+++ b/datafusion-federation/src/sql/executor.rs
@@ -1,9 +1,9 @@
+use arrow_schema::SchemaRef;
 use async_trait::async_trait;
 use core::fmt;
-use datafusion::{
-    arrow::datatypes::SchemaRef, error::Result, physical_plan::SendableRecordBatchStream,
-    sql::sqlparser::ast, sql::unparser::dialect::Dialect,
-};
+use datafusion_common::Result;
+use datafusion_execution::SendableRecordBatchStream;
+use datafusion_sql::{sqlparser::ast, unparser::dialect::Dialect};
 use std::sync::Arc;
 
 pub type SQLExecutorRef = Arc<dyn SQLExecutor>;

--- a/datafusion-federation/src/sql/executor.rs
+++ b/datafusion-federation/src/sql/executor.rs
@@ -1,9 +1,11 @@
-use arrow_schema::SchemaRef;
 use async_trait::async_trait;
 use core::fmt;
-use datafusion_common::Result;
-use datafusion_execution::SendableRecordBatchStream;
-use datafusion_sql::{sqlparser::ast, unparser::dialect::Dialect};
+use datafusion::{
+    arrow::datatypes::SchemaRef,
+    common::Result,
+    execution::SendableRecordBatchStream,
+    sql::{sqlparser::ast, unparser::dialect::Dialect},
+};
 use std::sync::Arc;
 
 pub type SQLExecutorRef = Arc<dyn SQLExecutor>;

--- a/datafusion-federation/src/sql/mod.rs
+++ b/datafusion-federation/src/sql/mod.rs
@@ -419,14 +419,6 @@ fn rewrite_table_scans_in_expr(
                 try_cast.data_type,
             )))
         }
-        Expr::Sort(sort) => {
-            let expr = rewrite_table_scans_in_expr(*sort.expr, known_rewrites)?;
-            Ok(Expr::Sort(Sort::new(
-                Box::new(expr),
-                sort.asc,
-                sort.nulls_first,
-            )))
-        }
         Expr::ScalarFunction(sf) => {
             let args = sf
                 .args
@@ -451,10 +443,13 @@ fn rewrite_table_scans_in_expr(
                 .map(Box::new);
             let order_by = af
                 .order_by
-                .map(|e| {
-                    e.into_iter()
-                        .map(|e| rewrite_table_scans_in_expr(e, known_rewrites))
-                        .collect::<Result<Vec<Expr>>>()
+                .map(|s| {
+                    s.into_iter()
+                        .map(|s| {
+                            rewrite_table_scans_in_expr(s.expr, known_rewrites)
+                                .map(|e| Sort::new(e, s.asc, s.nulls_first))
+                        })
+                        .collect::<Result<Vec<Sort>>>()
                 })
                 .transpose()?;
             Ok(Expr::AggregateFunction(AggregateFunction {
@@ -480,8 +475,11 @@ fn rewrite_table_scans_in_expr(
             let order_by = wf
                 .order_by
                 .into_iter()
-                .map(|e| rewrite_table_scans_in_expr(e, known_rewrites))
-                .collect::<Result<Vec<Expr>>>()?;
+                .map(|s| {
+                    rewrite_table_scans_in_expr(s.expr, known_rewrites)
+                        .map(|e| Sort::new(e, s.asc, s.nulls_first))
+                })
+                .collect::<Result<Vec<Sort>>>()?;
             Ok(Expr::WindowFunction(WindowFunction {
                 fun: wf.fun,
                 args,
@@ -533,13 +531,14 @@ fn rewrite_table_scans_in_expr(
                 is.negated,
             )))
         }
-        Expr::Wildcard { qualifier } => {
+        Expr::Wildcard { qualifier, options } => {
             if let Some(rewrite) = qualifier.as_ref().and_then(|q| known_rewrites.get(q)) {
                 Ok(Expr::Wildcard {
                     qualifier: Some(rewrite.clone()),
+                    options,
                 })
             } else {
-                Ok(Expr::Wildcard { qualifier })
+                Ok(Expr::Wildcard { qualifier, options })
             }
         }
         Expr::GroupingSet(gs) => match gs {

--- a/datafusion-federation/src/sql/mod.rs
+++ b/datafusion-federation/src/sql/mod.rs
@@ -3,27 +3,28 @@ mod schema;
 
 use std::{any::Any, collections::HashMap, fmt, sync::Arc, vec};
 
-use arrow_schema::{Schema, SchemaRef};
 use async_trait::async_trait;
-use datafusion::execution::SessionState;
-use datafusion_common::{Column, Result};
-use datafusion_execution::{SendableRecordBatchStream, TaskContext};
-use datafusion_expr::{
-    expr::{
-        AggregateFunction, Alias, Exists, InList, InSubquery, ScalarFunction, Sort, Unnest,
-        WindowFunction,
+use datafusion::{
+    arrow::datatypes::{Schema, SchemaRef},
+    common::{Column, Result},
+    execution::{SendableRecordBatchStream, SessionState, TaskContext},
+    logical_expr::{
+        expr::{
+            AggregateFunction, Alias, Exists, InList, InSubquery, ScalarFunction, Sort, Unnest,
+            WindowFunction,
+        },
+        Between, BinaryExpr, Case, Cast, Expr, Extension, GroupingSet, Like, LogicalPlan, Subquery,
+        TryCast,
     },
-    Between, BinaryExpr, Case, Cast, Expr, Extension, GroupingSet, Like, LogicalPlan, Subquery,
-    TryCast,
-};
-use datafusion_optimizer::{Optimizer, OptimizerConfig, OptimizerRule};
-use datafusion_physical_expr::EquivalenceProperties;
-use datafusion_physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionMode, ExecutionPlan, Partitioning, PlanProperties,
-};
-use datafusion_sql::{
-    unparser::{plan_to_sql, Unparser},
-    TableReference,
+    optimizer::{Optimizer, OptimizerConfig, OptimizerRule},
+    physical_expr::EquivalenceProperties,
+    physical_plan::{
+        DisplayAs, DisplayFormatType, ExecutionMode, ExecutionPlan, Partitioning, PlanProperties,
+    },
+    sql::{
+        unparser::{plan_to_sql, Unparser},
+        TableReference,
+    },
 };
 
 pub use executor::{SQLExecutor, SQLExecutorRef};
@@ -717,15 +718,16 @@ mod tests {
     use super::*;
     use crate::FederatedTableProviderAdaptor;
 
-    use arrow_schema::{DataType, Field};
     use datafusion::{
-        catalog_common::MemorySchemaProvider, datasource::DefaultTableSource,
+        arrow::datatypes::{DataType, Field},
+        catalog::{SchemaProvider, TableProvider},
+        catalog_common::MemorySchemaProvider,
+        common::DataFusionError,
+        datasource::DefaultTableSource,
+        logical_expr::LogicalPlanBuilder,
         prelude::SessionContext,
+        sql::unparser::dialect::{DefaultDialect, Dialect},
     };
-    use datafusion_catalog::{SchemaProvider, TableProvider};
-    use datafusion_common::DataFusionError;
-    use datafusion_expr::LogicalPlanBuilder;
-    use datafusion_sql::unparser::dialect::{DefaultDialect, Dialect};
 
     struct TestSQLExecutor {}
 

--- a/datafusion-federation/src/sql/schema.rs
+++ b/datafusion-federation/src/sql/schema.rs
@@ -1,10 +1,12 @@
 use std::{any::Any, sync::Arc};
 
-use arrow_schema::SchemaRef;
 use async_trait::async_trait;
-use datafusion_catalog::{SchemaProvider, TableProvider};
-use datafusion_common::Result;
-use datafusion_expr::{TableSource, TableType};
+use datafusion::{
+    arrow::datatypes::SchemaRef,
+    catalog::{SchemaProvider, TableProvider},
+    common::Result,
+    logical_expr::{TableSource, TableType},
+};
 use futures::future::join_all;
 
 use crate::{

--- a/datafusion-federation/src/sql/schema.rs
+++ b/datafusion-federation/src/sql/schema.rs
@@ -1,10 +1,10 @@
 use std::{any::Any, sync::Arc};
 
+use arrow_schema::SchemaRef;
 use async_trait::async_trait;
-use datafusion::logical_expr::{TableSource, TableType};
-use datafusion::{
-    arrow::datatypes::SchemaRef, catalog::SchemaProvider, datasource::TableProvider, error::Result,
-};
+use datafusion_catalog::{SchemaProvider, TableProvider};
+use datafusion_common::Result;
+use datafusion_expr::{TableSource, TableType};
 use futures::future::join_all;
 
 use crate::{

--- a/datafusion-federation/src/table_provider.rs
+++ b/datafusion-federation/src/table_provider.rs
@@ -1,15 +1,11 @@
 use std::{any::Any, borrow::Cow, sync::Arc};
 
+use arrow_schema::SchemaRef;
 use async_trait::async_trait;
-use datafusion::{
-    arrow::datatypes::SchemaRef,
-    catalog::Session,
-    common::Constraints,
-    datasource::TableProvider,
-    error::{DataFusionError, Result},
-    logical_expr::{Expr, LogicalPlan, TableProviderFilterPushDown, TableSource, TableType},
-    physical_plan::ExecutionPlan,
-};
+use datafusion_catalog::{Session, TableProvider};
+use datafusion_common::{Constraints, DataFusionError, Result};
+use datafusion_expr::{Expr, LogicalPlan, TableProviderFilterPushDown, TableSource, TableType};
+use datafusion_physical_plan::ExecutionPlan;
 
 use crate::FederationProvider;
 

--- a/datafusion-federation/src/table_provider.rs
+++ b/datafusion-federation/src/table_provider.rs
@@ -1,11 +1,13 @@
 use std::{any::Any, borrow::Cow, sync::Arc};
 
-use arrow_schema::SchemaRef;
 use async_trait::async_trait;
-use datafusion_catalog::{Session, TableProvider};
-use datafusion_common::{Constraints, DataFusionError, Result};
-use datafusion_expr::{Expr, LogicalPlan, TableProviderFilterPushDown, TableSource, TableType};
-use datafusion_physical_plan::ExecutionPlan;
+use datafusion::{
+    arrow::datatypes::SchemaRef,
+    catalog::{Session, TableProvider},
+    common::{Constraints, DataFusionError, Result},
+    logical_expr::{Expr, LogicalPlan, TableProviderFilterPushDown, TableSource, TableType},
+    physical_plan::ExecutionPlan,
+};
 
 use crate::FederationProvider;
 

--- a/datafusion-federation/src/table_provider.rs
+++ b/datafusion-federation/src/table_provider.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, sync::Arc};
+use std::{any::Any, borrow::Cow, sync::Arc};
 
 use async_trait::async_trait;
 use datafusion::{
@@ -70,7 +70,7 @@ impl TableProvider for FederatedTableProviderAdaptor {
 
         self.source.table_type()
     }
-    fn get_logical_plan(&self) -> Option<&LogicalPlan> {
+    fn get_logical_plan(&self) -> Option<Cow<LogicalPlan>> {
         if let Some(table_provider) = &self.table_provider {
             return table_provider
                 .get_logical_plan()

--- a/datafusion-flight-sql-server/Cargo.toml
+++ b/datafusion-flight-sql-server/Cargo.toml
@@ -11,10 +11,14 @@ name = "datafusion_flight_sql_server"
 path = "src/lib.rs"
 
 [dependencies]
-arrow.workspace = true
+arrow-array.workspace = true
 arrow-flight.workspace = true
+arrow-ipc.workspace = true
+arrow-schema.workspace = true
 datafusion.workspace = true
-datafusion-federation = { workspace = true, features = ["sql"] }
+datafusion-common.workspace = true
+datafusion-execution.workspace = true
+datafusion-expr.workspace = true
 datafusion-substrait.workspace = true
 
 futures = "0.3.30"
@@ -29,5 +33,7 @@ tonic = { version = "0.12.1", features = [
 ] }
 
 [dev-dependencies]
+datafusion-catalog.workspace = true
+datafusion-federation = { workspace = true, features = ["sql"] }
 datafusion-flight-sql-table-provider = { path = "../datafusion-flight-sql-table-provider" }
 tokio = { version = "1.39.3", features = ["full"] }

--- a/datafusion-flight-sql-server/Cargo.toml
+++ b/datafusion-flight-sql-server/Cargo.toml
@@ -11,23 +11,23 @@ name = "datafusion_flight_sql_server"
 path = "src/lib.rs"
 
 [dependencies]
+arrow.workspace = true
+arrow-flight.workspace = true
 datafusion.workspace = true
-datafusion-substrait.workspace = true
 datafusion-federation = { workspace = true, features = ["sql"] }
+datafusion-substrait.workspace = true
 
 futures = "0.3.30"
-tonic = { version = "0.11.0", features = [
+log = "0.4.22"
+once_cell = "1.19.0"
+prost = "0.13.1"
+tonic = { version = "0.12.1", features = [
     "tls",
     "transport",
     "codegen",
     "prost",
 ] }
-prost = "0.12.3"
-arrow = "52.0.0"
-arrow-flight = { version = "52.2.0", features = ["flight-sql-experimental"] }
-log = "0.4.22"
-once_cell = "1.19.0"
 
 [dev-dependencies]
-tokio = { version = "1.39.3", features = ["full"] }
 datafusion-flight-sql-table-provider = { path = "../datafusion-flight-sql-table-provider" }
+tokio = { version = "1.39.3", features = ["full"] }

--- a/datafusion-flight-sql-server/Cargo.toml
+++ b/datafusion-flight-sql-server/Cargo.toml
@@ -11,14 +11,8 @@ name = "datafusion_flight_sql_server"
 path = "src/lib.rs"
 
 [dependencies]
-arrow-array.workspace = true
 arrow-flight.workspace = true
-arrow-ipc.workspace = true
-arrow-schema.workspace = true
 datafusion.workspace = true
-datafusion-common.workspace = true
-datafusion-execution.workspace = true
-datafusion-expr.workspace = true
 datafusion-substrait.workspace = true
 
 futures = "0.3.30"
@@ -33,7 +27,6 @@ tonic = { version = "0.12.1", features = [
 ] }
 
 [dev-dependencies]
-datafusion-catalog.workspace = true
 datafusion-federation = { workspace = true, features = ["sql"] }
 datafusion-flight-sql-table-provider = { path = "../datafusion-flight-sql-table-provider" }
 tokio = { version = "1.39.3", features = ["full"] }

--- a/datafusion-flight-sql-server/examples/flight-sql.rs
+++ b/datafusion-flight-sql-server/examples/flight-sql.rs
@@ -2,11 +2,11 @@ use std::{sync::Arc, time::Duration};
 
 use arrow_flight::sql::client::FlightSqlServiceClient;
 use datafusion::{
+    catalog::SchemaProvider,
+    common::{DataFusionError, Result},
     execution::SessionState,
     prelude::{CsvReadOptions, SessionContext},
 };
-use datafusion_catalog::SchemaProvider;
-use datafusion_common::{DataFusionError, Result};
 use datafusion_federation::sql::{SQLFederationProvider, SQLSchemaProvider};
 use datafusion_flight_sql_server::service::FlightSqlService;
 use datafusion_flight_sql_table_provider::FlightSQLExecutor;

--- a/datafusion-flight-sql-server/examples/flight-sql.rs
+++ b/datafusion-flight-sql-server/examples/flight-sql.rs
@@ -2,13 +2,11 @@ use std::{sync::Arc, time::Duration};
 
 use arrow_flight::sql::client::FlightSqlServiceClient;
 use datafusion::{
-    catalog::SchemaProvider,
-    error::{DataFusionError, Result},
-    execution::{
-        context::{SessionContext, SessionState},
-        options::CsvReadOptions,
-    },
+    execution::SessionState,
+    prelude::{CsvReadOptions, SessionContext},
 };
+use datafusion_catalog::SchemaProvider;
+use datafusion_common::{DataFusionError, Result};
 use datafusion_federation::sql::{SQLFederationProvider, SQLSchemaProvider};
 use datafusion_flight_sql_server::service::FlightSqlService;
 use datafusion_flight_sql_table_provider::FlightSQLExecutor;

--- a/datafusion-flight-sql-server/src/service.rs
+++ b/datafusion-flight-sql-server/src/service.rs
@@ -1,6 +1,5 @@
 use std::{pin::Pin, sync::Arc};
 
-use arrow_array::{ArrayRef, RecordBatch, StringArray};
 use arrow_flight::sql::{
     self,
     server::{FlightSqlService as ArrowFlightSqlService, PeekableFlightDataStream},
@@ -22,15 +21,18 @@ use arrow_flight::{
     Action, FlightDescriptor, FlightEndpoint, FlightInfo, HandshakeRequest, HandshakeResponse,
     IpcMessage, SchemaAsIpc, Ticket,
 };
-use arrow_ipc::writer::IpcWriteOptions;
-use arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef};
 use datafusion::{
-    execution::SessionState,
+    arrow::{
+        array::{ArrayRef, RecordBatch, StringArray},
+        datatypes::{DataType, Field, Schema, SchemaRef},
+        error::ArrowError,
+        ipc::writer::IpcWriteOptions,
+    },
+    common::{DataFusionError, Result as DataFusionResult},
+    execution::{SendableRecordBatchStream, SessionState},
+    logical_expr::{LogicalPlan, TableType},
     prelude::{DataFrame, SQLOptions, SessionContext},
 };
-use datafusion_common::{DataFusionError, Result as DataFusionResult};
-use datafusion_execution::SendableRecordBatchStream;
-use datafusion_expr::{LogicalPlan, TableType};
 use datafusion_substrait::{
     logical_plan::consumer::from_substrait_plan, serializer::deserialize_bytes,
 };

--- a/datafusion-flight-sql-server/src/service.rs
+++ b/datafusion-flight-sql-server/src/service.rs
@@ -1,11 +1,6 @@
 use std::{pin::Pin, sync::Arc};
 
-use arrow::{
-    array::{ArrayRef, RecordBatch, StringArray},
-    datatypes::{DataType, Field, SchemaRef},
-    error::ArrowError,
-    ipc::writer::IpcWriteOptions,
-};
+use arrow_array::{ArrayRef, RecordBatch, StringArray};
 use arrow_flight::sql::{
     self,
     server::{FlightSqlService as ArrowFlightSqlService, PeekableFlightDataStream},
@@ -27,15 +22,15 @@ use arrow_flight::{
     Action, FlightDescriptor, FlightEndpoint, FlightInfo, HandshakeRequest, HandshakeResponse,
     IpcMessage, SchemaAsIpc, Ticket,
 };
+use arrow_ipc::writer::IpcWriteOptions;
+use arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef};
 use datafusion::{
-    common::arrow::datatypes::Schema,
-    dataframe::DataFrame,
-    datasource::TableType,
-    error::{DataFusionError, Result as DataFusionResult},
-    execution::context::{SQLOptions, SessionContext, SessionState},
-    logical_expr::LogicalPlan,
-    physical_plan::SendableRecordBatchStream,
+    execution::SessionState,
+    prelude::{DataFrame, SQLOptions, SessionContext},
 };
+use datafusion_common::{DataFusionError, Result as DataFusionResult};
+use datafusion_execution::SendableRecordBatchStream;
+use datafusion_expr::{LogicalPlan, TableType};
 use datafusion_substrait::{
     logical_plan::consumer::from_substrait_plan, serializer::deserialize_bytes,
 };

--- a/datafusion-flight-sql-server/src/session.rs
+++ b/datafusion-flight-sql-server/src/session.rs
@@ -1,4 +1,4 @@
-use datafusion::execution::context::SessionState;
+use datafusion::execution::SessionState;
 use tonic::{Request, Status};
 
 type Result<T, E = Status> = std::result::Result<T, E>;

--- a/datafusion-flight-sql-table-provider/Cargo.toml
+++ b/datafusion-flight-sql-table-provider/Cargo.toml
@@ -6,16 +6,16 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
+arrow.workspace = true
+arrow-flight.workspace = true
 async-trait.workspace = true
 datafusion.workspace = true
 datafusion-federation = { workspace = true, features = ["sql"] }
 
 futures = "0.3.30"
-tonic = { version = "0.11.0", features = [
+tonic = { version = "0.12.1", features = [
     "tls",
     "transport",
     "codegen",
     "prost",
 ] }
-arrow = "52.0.0"
-arrow-flight = { version = "52.2.0", features = ["flight-sql-experimental"] }

--- a/datafusion-flight-sql-table-provider/Cargo.toml
+++ b/datafusion-flight-sql-table-provider/Cargo.toml
@@ -6,11 +6,14 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-arrow.workspace = true
 arrow-flight.workspace = true
+arrow-schema.workspace = true
 async-trait.workspace = true
-datafusion.workspace = true
+datafusion-common.workspace = true
+datafusion-execution.workspace = true
 datafusion-federation = { workspace = true, features = ["sql"] }
+datafusion-physical-plan.workspace = true
+datafusion-sql.workspace = true
 
 futures = "0.3.30"
 tonic = { version = "0.12.1", features = [

--- a/datafusion-flight-sql-table-provider/src/lib.rs
+++ b/datafusion-flight-sql-table-provider/src/lib.rs
@@ -1,14 +1,13 @@
 use std::sync::Arc;
 
-use arrow::{datatypes::SchemaRef, error::ArrowError};
 use arrow_flight::sql::client::FlightSqlServiceClient;
+use arrow_schema::{ArrowError, SchemaRef};
 use async_trait::async_trait;
-use datafusion::{
-    error::{DataFusionError, Result},
-    physical_plan::{stream::RecordBatchStreamAdapter, SendableRecordBatchStream},
-    sql::unparser::dialect::{DefaultDialect, Dialect},
-};
+use datafusion_common::{DataFusionError, Result};
+use datafusion_execution::SendableRecordBatchStream;
 use datafusion_federation::sql::SQLExecutor;
+use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion_sql::unparser::dialect::{DefaultDialect, Dialect};
 use futures::TryStreamExt;
 use tonic::transport::Channel;
 


### PR DESCRIPTION
upgrade datafusion to 42 and arrow to 53.
the `.taplo.toml` file is copied from `dadafusion`.
BTW, I think we don't need `datafusion` and `arrow` dependencies, just need subcrates like `dadafusion-expr` and `arrow-array`. If you agree, I would do this.