### PR TITLE
Default session state should include default features

### DIFF
--- a/datafusion-federation/src/lib.rs
+++ b/datafusion-federation/src/lib.rs
@@ -27,6 +27,7 @@ pub fn default_session_state() -> SessionState {
     SessionStateBuilder::new()
         .with_optimizer_rules(rules)
         .with_query_planner(Arc::new(FederatedQueryPlanner::new()))
+        .with_default_features()
         .build()
 }
 


### PR DESCRIPTION
Default session state should include default features, otherwise some basic aggregation function (e.g., `Count`) will not be supported:

```rust
let state = datafusion_federation::default_session_state();
let ctx = SessionContext::new_with_state(state);
let query = r#"SELECT COUNT(*) FROM hits"#;
let df = ctx.sql(query).await?;
```

will panic:

```
No candidates provided.
stack backtrace:
   0: rust_begin_unwind
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/std/src/panicking.rs:665:5
   1: core::panicking::panic_fmt
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/core/src/panicking.rs:74:14
   2: core::panicking::panic_display
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/core/src/panicking.rs:264:5
   3: core::option::expect_failed
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/core/src/option.rs:2025:5
   4: core::option::Option<T>::expect
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/core/src/option.rs:928:21
   5: datafusion_sql::expr::function::find_closest_match
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/datafusion-sql-42.1.0/src/expr/function.rs:72:5
   6: datafusion_sql::expr::function::suggest_valid_function
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/datafusion-sql-42.1.0/src/expr/function.rs:65:5
   7: datafusion_sql::expr::function::<impl datafusion_sql::planner::SqlToRel<S>>::sql_function_to_expr
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/datafusion-sql-42.1.0/src/expr/function.rs:357:13
   8: datafusion_sql::expr::<impl datafusion_sql::planner::SqlToRel<S>>::sql_expr_to_logical_expr_internal
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/datafusion-sql-42.1.0/src/expr/mod.rs:448:17
   9: datafusion_sql::expr::<impl datafusion_sql::planner::SqlToRel<S>>::sql_expr_to_logical_expr
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/datafusion-sql-42.1.0/src/expr/mod.rs:82:40
  10: datafusion_sql::expr::<impl datafusion_sql::planner::SqlToRel<S>>::sql_to_expr
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/datafusion-sql-42.1.0/src/expr/mod.rs:140:24
  11: datafusion_sql::select::<impl datafusion_sql::planner::SqlToRel<S>>::sql_select_to_rex
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/datafusion-sql-42.1.0/src/select.rs:552:28
  12: datafusion_sql::select::<impl datafusion_sql::planner::SqlToRel<S>>::prepare_select_exprs::{{closure}}
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/datafusion-sql-42.1.0/src/select.rs:534:25
  13: core::iter::adapters::map::map_try_fold::{{closure}}
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/core/src/iter/adapters/map.rs:95:28
  14: <alloc::vec::into_iter::IntoIter<T,A> as core::iter::traits::iterator::Iterator>::try_fold
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/alloc/src/vec/into_iter.rs:346:25
  15: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::try_fold
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/core/src/iter/adapters/map.rs:121:9
  16: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::try_fold
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/core/src/iter/adapters/map.rs:121:9
  17: <core::iter::adapters::fuse::Fuse<I> as core::iter::adapters::fuse::FuseImpl<I>>::try_fold
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/core/src/iter/adapters/fuse.rs:375:19
  18: <core::iter::adapters::fuse::Fuse<I> as core::iter::traits::iterator::Iterator>::try_fold
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/core/src/iter/adapters/fuse.rs:89:9
  19: core::iter::adapters::flatten::FlattenCompat<I,U>::iter_try_fold
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/core/src/iter/adapters/flatten.rs:513:25
  20: <core::iter::adapters::flatten::FlattenCompat<I,U> as core::iter::traits::iterator::Iterator>::try_fold
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/core/src/iter/adapters/flatten.rs:651:9
  21: <core::iter::adapters::flatten::FlatMap<I,U,F> as core::iter::traits::iterator::Iterator>::try_fold
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/core/src/iter/adapters/flatten.rs:79:9
  22: <core::iter::adapters::GenericShunt<I,R> as core::iter::traits::iterator::Iterator>::try_fold
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/core/src/iter/adapters/mod.rs:191:9
  23: core::iter::traits::iterator::Iterator::try_for_each
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/core/src/iter/traits/iterator.rs:2467:9
  24: <core::iter::adapters::GenericShunt<I,R> as core::iter::traits::iterator::Iterator>::next
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/core/src/iter/adapters/mod.rs:174:14
  25: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter_nested::SpecFromIterNested<T,I>>::from_iter
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/alloc/src/vec/spec_from_iter_nested.rs:24:32
  26: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter::SpecFromIter<T,I>>::from_iter
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/alloc/src/vec/spec_from_iter.rs:33:9
  27: <alloc::vec::Vec<T> as core::iter::traits::collect::FromIterator<T>>::from_iter
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/alloc/src/vec/mod.rs:2989:9
  28: core::iter::traits::iterator::Iterator::collect
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/core/src/iter/traits/iterator.rs:2000:9
  29: <core::result::Result<V,E> as core::iter::traits::collect::FromIterator<core::result::Result<A,E>>>::from_iter::{{closure}}
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/core/src/result.rs:1958:51
  30: core::iter::adapters::try_process
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/core/src/iter/adapters/mod.rs:160:17
  31: <core::result::Result<V,E> as core::iter::traits::collect::FromIterator<core::result::Result<A,E>>>::from_iter
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/core/src/result.rs:1958:9
  32: core::iter::traits::iterator::Iterator::collect
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/core/src/iter/traits/iterator.rs:2000:9
  33: datafusion_sql::select::<impl datafusion_sql::planner::SqlToRel<S>>::prepare_select_exprs
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/datafusion-sql-42.1.0/src/select.rs:532:9
  34: datafusion_sql::select::<impl datafusion_sql::planner::SqlToRel<S>>::select_to_plan
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/datafusion-sql-42.1.0/src/select.rs:83:28
  35: datafusion_sql::query::<impl datafusion_sql::planner::SqlToRel<S>>::query_to_plan
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/datafusion-sql-42.1.0/src/query.rs:56:28
  36: datafusion_sql::statement::<impl datafusion_sql::planner::SqlToRel<S>>::sql_statement_to_plan_with_context_impl
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/datafusion-sql-42.1.0/src/statement.rs:215:40
  37: datafusion_sql::statement::<impl datafusion_sql::planner::SqlToRel<S>>::sql_statement_to_plan
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/datafusion-sql-42.1.0/src/statement.rs:178:9
  38: datafusion_sql::statement::<impl datafusion_sql::planner::SqlToRel<S>>::statement_to_plan
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/datafusion-sql-42.1.0/src/statement.rs:166:42
  39: datafusion::execution::session_state::SessionState::statement_to_plan::{{closure}}
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/datafusion-42.1.0/src/execution/session_state.rs:572:9
  40: datafusion::execution::session_state::SessionState::create_logical_plan::{{closure}}
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/datafusion-42.1.0/src/execution/session_state.rs:605:54
  41: datafusion::execution::context::SessionContext::sql_with_options::{{closure}}
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/datafusion-42.1.0/src/execution/context/mod.rs:582:58
  42: datafusion::execution::context::SessionContext::sql::{{closure}}
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/datafusion-42.1.0/src/execution/context/mod.rs:548:55
  43: flight_sql2::main::{{closure}}
             at ./datafusion-flight-sql-server/examples/flight-sql2.rs:32:29
  44: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/core/src/future/future.rs:123:9
  45: tokio::runtime::park::CachedParkThread::block_on::{{closure}}
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.41.0/src/runtime/park.rs:281:63
  46: tokio::runtime::coop::with_budget
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.41.0/src/runtime/coop.rs:107:5
  47: tokio::runtime::coop::budget
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.41.0/src/runtime/coop.rs:73:5
  48: tokio::runtime::park::CachedParkThread::block_on
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.41.0/src/runtime/park.rs:281:31
  49: tokio::runtime::context::blocking::BlockingRegionGuard::block_on
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.41.0/src/runtime/context/blocking.rs:66:9
  50: tokio::runtime::scheduler::multi_thread::MultiThread::block_on::{{closure}}
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.41.0/src/runtime/scheduler/multi_thread/mod.rs:87:13
  51: tokio::runtime::context::runtime::enter_runtime
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.41.0/src/runtime/context/runtime.rs:65:16
  52: tokio::runtime::scheduler::multi_thread::MultiThread::block_on
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.41.0/src/runtime/scheduler/multi_thread/mod.rs:86:9
  53: tokio::runtime::runtime::Runtime::block_on_inner
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.41.0/src/runtime/runtime.rs:370:45
  54: tokio::runtime::runtime::Runtime::block_on
             at /home/hao/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.41.0/src/runtime/runtime.rs:340:13
  55: flight_sql2::main
             at ./datafusion-flight-sql-server/examples/flight-sql2.rs:37:5
  56: core::ops::function::FnOnce::call_once
             at /rustc/d6c8169c186ab16a3404cd0d0866674018e8a19e/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```