### PR TITLE
github/workflows/release_plz: ignore flight-sql-table-provider crate

### DIFF
--- a/.github/workflows/release_plz.yml
+++ b/.github/workflows/release_plz.yml
@@ -44,10 +44,24 @@ jobs:
           fetch-depth: 0
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - name: Close old release PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # List all opened PRs which head branch starts with "release-plz-"
+          release_pr=$(gh pr list --state='open' --json number,headRefName --jq '.[] | select(.headRefName | startswith("release-plz-")) | .number')
+          # Close the release PR if there is one
+          if [[ -n "$release_pr" ]]; then
+            echo "Closing old release PR $release_pr"
+            gh pr close $release_pr
+          else
+            echo "No open release PR"
+          fi
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         with:
           command: release-pr
+          config: .release-plz.toml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -1,0 +1,5 @@
+[[package]] 
+name = "datafusion-flight-sql-table-provider"
+changelog_update = false 
+git_release_enable = false 
+publish = false 


### PR DESCRIPTION
This PR also remove the old PRs created by release_plz