### PR TITLE
feat: support prepared statement parameters

### DIFF
--- a/datafusion-flight-sql-server/src/state.rs
+++ b/datafusion-flight-sql-server/src/state.rs
@@ -55,29 +55,52 @@ fn decode_error_flight_error(err: prost::DecodeError) -> FlightError {
 /// Represents a query handle for use in prepared statements.
 /// All state required to run the prepared statement is passed
 /// back and forth to the client, so any service instance can run it
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct QueryHandle {
     /// The raw SQL query text
     query: String,
+    parameters: Option<Bytes>,
 }
 
 impl QueryHandle {
-    pub fn new(query: String) -> Self {
-        Self { query }
+    pub fn new(query: String, parameters: Option<Bytes>) -> Self {
+        Self { query, parameters }
     }
 
     pub fn query(&self) -> &str {
         self.query.as_ref()
     }
 
-    pub fn try_decode(handle: Bytes) -> Result<Self> {
-        let query = String::from_utf8(handle.to_vec())
-            .map_err(|e| FlightError::ExternalError(Box::new(e.utf8_error())))?;
-        Ok(Self { query })
+    pub fn parameters(&self) -> Option<&[u8]> {
+        self.parameters.as_deref()
+    }
+
+    pub fn set_parameters(&mut self, parameters: Option<Bytes>) {
+        self.parameters = parameters;
+    }
+
+    pub fn try_decode(msg: Bytes) -> Result<Self> {
+        let msg = QueryHandleMessage::decode(msg).map_err(decode_error_flight_error)?;
+
+        Ok(Self {
+            query: msg.query,
+            parameters: msg.parameters,
+        })
     }
 
     pub fn encode(self) -> Bytes {
-        Bytes::from(self.query.into_bytes())
+        let msg = QueryHandleMessage {
+            query: self.query,
+            parameters: self.parameters,
+        };
+
+        msg.encode_to_vec().into()
+    }
+}
+
+impl From<QueryHandle> for Bytes {
+    fn from(value: QueryHandle) -> Self {
+        value.encode()
     }
 }
 
@@ -87,9 +110,11 @@ impl Display for QueryHandle {
     }
 }
 
-/// Encode a QueryHandle as Bytes
-impl From<QueryHandle> for Bytes {
-    fn from(value: QueryHandle) -> Self {
-        Self::from(value.query.into_bytes())
-    }
+#[derive(Clone, PartialEq, Message)]
+pub struct QueryHandleMessage {
+    /// The raw SQL query text
+    #[prost(string, tag = "1")]
+    query: String,
+    #[prost(bytes = "bytes", optional, tag = "2")]
+    parameters: Option<Bytes>,
 }


### PR DESCRIPTION
This adds support for prepared statement parameters. Parameters will be parsed from the SQL query and can be supplied using do_put_prepared_statement_query providing a record batch with a single row and a column for each parameter.

The QueryHandler is updated to contain the encoded parameters as a record batch.