### PR TITLE
flight-sql-server: Add `protoc` as feature in Cargo.toml when building substrait dependency

### DIFF
--- a/datafusion-flight-sql-server/Cargo.toml
+++ b/datafusion-flight-sql-server/Cargo.toml
@@ -14,14 +14,14 @@ path = "src/lib.rs"
 arrow-flight.workspace = true
 arrow.workspace = true
 datafusion-federation = { workspace = true, features = ["sql"] }
-datafusion-substrait.workspace = true
+datafusion-substrait = { workspace = true, features = ["protoc"] }
 datafusion.workspace = true
 futures.workspace = true
 log = "0.4.22"
 once_cell = "1.19.0"
 prost = "0.13.1"
 tonic.workspace = true
-async-trait.workspace = true 
+async-trait.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true


### PR DESCRIPTION
According to [substrait-rs documentation](https://github.com/substrait-io/substrait-rs/blob/main/CONTRIBUTING.md?plain=1#L52):
> In environments where no `protoc` is available the `protoc` feature can
> be enabled to build `protoc` from source: