### PR TITLE
Upgrade datafusion to version 47

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ readme = "README.md"
 repository = "https://github.com/datafusion-contrib/datafusion-federation"
 
 [workspace.dependencies]
-arrow-json = "54"
+arrow-json = "55"
 async-stream = "0.3.5"
 async-trait = "0.1.83"
-datafusion = "46.0.1"
+datafusion = "47.0.0"
 datafusion-federation = { path = "./datafusion-federation", version = "0.4.0" }
 futures = "0.3.31"
 tokio = { version = "1.41", features = ["full"] }


### PR DESCRIPTION
Among other things, version 47 contains fixes to the SQL unparser such as https://github.com/apache/datafusion/pull/15212 and https://github.com/apache/datafusion/pull/15693, which directly impact `datafusion-federation` + `datafusion-table-providers`.