### PR TITLE
Keep the actions up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Check for updates every Monday
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Re-add .github/dependabot.yml to keep GitHub Actions up to date, it does not update Cargo dependencies.