### PR TITLE
Make VirtualExecutionPlan public

### DIFF
--- a/datafusion-federation/src/sql/mod.rs
+++ b/datafusion-federation/src/sql/mod.rs
@@ -154,7 +154,7 @@ impl FederationPlanner for SQLFederationPlanner {
 }
 
 #[derive(Debug, Clone)]
-struct VirtualExecutionPlan {
+pub struct VirtualExecutionPlan {
     plan: LogicalPlan,
     executor: Arc<dyn SQLExecutor>,
     props: PlanProperties,
@@ -176,6 +176,18 @@ impl VirtualExecutionPlan {
             props,
             statistics,
         }
+    }
+
+    pub fn plan(&self) -> &LogicalPlan {
+        &self.plan
+    }
+
+    pub fn executor(&self) -> &Arc<dyn SQLExecutor> {
+        &self.executor
+    }
+
+    pub fn statistics(&self) -> &Statistics {
+        &self.statistics
     }
 
     fn schema(&self) -> SchemaRef {


### PR DESCRIPTION
Makes the `VirtualExecutionPlan` struct public, as well as providing getters for some of its fields, allowing more flexibility in external modules. This is in line with Datafusion's native physical operators, such as [`ProjectionExec`](https://github.com/apache/datafusion/blob/350c61b23a2732ebd8e73cf08fe168cf6d73fb5b/datafusion/physical-plan/src/projection.rs#L57) or [`FilterExec`](https://github.com/apache/datafusion/blob/350c61b23a2732ebd8e73cf08fe168cf6d73fb5b/datafusion/physical-plan/src/filter.rs#L73).