### PR TITLE
Add metrics to `SchemaCastScanExec` and `VirtualExecutionPlan`

### DIFF
--- a/datafusion-federation/src/sql/executor.rs
+++ b/datafusion-federation/src/sql/executor.rs
@@ -5,7 +5,7 @@ use datafusion::{
     common::Statistics,
     error::Result,
     logical_expr::LogicalPlan,
-    physical_plan::SendableRecordBatchStream,
+    physical_plan::{metrics::MetricsSet, SendableRecordBatchStream},
     sql::{sqlparser::ast, unparser::dialect::Dialect},
 };
 use std::sync::Arc;
@@ -56,6 +56,11 @@ pub trait SQLExecutor: Sync + Send {
 
     /// Returns the schema of table_name within this [`SQLExecutor`]
     async fn get_table_schema(&self, table_name: &str) -> Result<SchemaRef>;
+
+    /// Returns the execution metrics, if available.
+    fn metrics(&self) -> Option<MetricsSet> {
+        None
+    }
 }
 
 impl fmt::Debug for dyn SQLExecutor {

--- a/datafusion-federation/src/sql/mod.rs
+++ b/datafusion-federation/src/sql/mod.rs
@@ -11,8 +11,10 @@ use analyzer::RewriteTableScanAnalyzer;
 use async_trait::async_trait;
 use datafusion::{
     arrow::datatypes::{Schema, SchemaRef},
-    common::tree_node::{Transformed, TreeNode},
-    common::Statistics,
+    common::{
+        tree_node::{Transformed, TreeNode},
+        Statistics,
+    },
     error::{DataFusionError, Result},
     execution::{context::SessionState, TaskContext},
     logical_expr::{Extension, LogicalPlan},
@@ -20,6 +22,7 @@ use datafusion::{
     physical_expr::EquivalenceProperties,
     physical_plan::{
         execution_plan::{Boundedness, EmissionType},
+        metrics::MetricsSet,
         DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
         SendableRecordBatchStream,
     },
@@ -364,6 +367,10 @@ impl ExecutionPlan for VirtualExecutionPlan {
 
     fn partition_statistics(&self, _partition: Option<usize>) -> Result<Statistics> {
         Ok(self.statistics.clone())
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        self.executor.metrics()
     }
 }
 


### PR DESCRIPTION
Adds execution metrics to `SchemaCastScanExec` (`elapsed_compute` and `num_rows`), as well as exposing the `metrics` method in the `SQLExecutor` to allow user-provided ones.