### PR TITLE
Pin Rust toolchain to 1.92.0 to match DataFusion v52

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.92.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Adds `rust-toolchain.toml` to pin the Rust version to 1.92.0, matching the toolchain used by DataFusion v52.