### PR TITLE
Upgrade to DataFusion v54

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/datafusion-contrib/datafusion-federation"
 arrow-json = "58.0"
 async-stream = "0.3"
 async-trait = "0.1"
-datafusion = "53"
+datafusion = "54"
 datafusion-federation = { path = "./datafusion-federation", version = "0.5.3" }
 futures = "0.3"
 tokio = { version = "1.41", features = ["full"] }

--- a/datafusion-federation/src/optimizer/mod.rs
+++ b/datafusion-federation/src/optimizer/mod.rs
@@ -1,5 +1,6 @@
 mod scan_result;
 
+use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::{
@@ -364,9 +365,8 @@ pub fn get_table_source(
     let source = source_as_provider(source)?;
 
     // Get FederatedTableProviderAdaptor
-    let Some(wrapper) = source
-        .as_any()
-        .downcast_ref::<FederatedTableProviderAdaptor>()
+    let Some(wrapper) =
+        (source.as_ref() as &dyn Any).downcast_ref::<FederatedTableProviderAdaptor>()
     else {
         return Ok(None);
     };

--- a/datafusion-federation/src/schema_cast/mod.rs
+++ b/datafusion-federation/src/schema_cast/mod.rs
@@ -12,7 +12,6 @@ use datafusion::physical_plan::{
     PlanProperties,
 };
 use futures::StreamExt;
-use std::any::Any;
 use std::clone::Clone;
 use std::fmt;
 use std::sync::Arc;
@@ -60,10 +59,6 @@ impl DisplayAs for SchemaCastScanExec {
 impl ExecutionPlan for SchemaCastScanExec {
     fn name(&self) -> &str {
         "SchemaCastScanExec"
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 
     fn properties(&self) -> &Arc<PlanProperties> {
@@ -127,7 +122,7 @@ impl ExecutionPlan for SchemaCastScanExec {
         )))
     }
 
-    fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
+    fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
         self.input.partition_statistics(partition)
     }
 

--- a/datafusion-federation/src/sql/analyzer.rs
+++ b/datafusion-federation/src/sql/analyzer.rs
@@ -1,12 +1,12 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{any::Any, collections::HashMap, sync::Arc};
 
 use datafusion::{
     common::{Column, Spans},
     logical_expr::{
         expr::{
-            AggregateFunction, AggregateFunctionParams, Alias, Exists, InList, InSubquery,
-            PlannedReplaceSelectItem, ScalarFunction, SetComparison, Sort, Unnest, WildcardOptions,
-            WindowFunction, WindowFunctionParams,
+            AggregateFunction, AggregateFunctionParams, Alias, Exists, HigherOrderFunction, InList,
+            InSubquery, Lambda, PlannedReplaceSelectItem, ScalarFunction, SetComparison, Sort,
+            Unnest, WildcardOptions, WindowFunction, WindowFunctionParams,
         },
         Between, BinaryExpr, Case, Cast, Expr, GroupingSet, Like, Limit, LogicalPlan, Subquery,
         TryCast,
@@ -46,7 +46,7 @@ fn rewrite_table_scans(
                 return Ok(plan.clone());
             };
 
-            match federated_source.as_any().downcast_ref::<SQLTableSource>() {
+            match (federated_source.as_ref() as &dyn Any).downcast_ref::<SQLTableSource>() {
                 Some(sql_table_source) => {
                     let remote_table_name = sql_table_source.table_reference();
                     known_rewrites.insert(original_table_name, remote_table_name.clone());
@@ -351,13 +351,13 @@ fn rewrite_table_scans_in_expr(
         }
         Expr::Cast(cast) => {
             let expr = rewrite_table_scans_in_expr(*cast.expr, known_rewrites)?;
-            Ok(Expr::Cast(Cast::new(Box::new(expr), cast.data_type)))
+            Ok(Expr::Cast(Cast::new_from_field(Box::new(expr), cast.field)))
         }
         Expr::TryCast(try_cast) => {
             let expr = rewrite_table_scans_in_expr(*try_cast.expr, known_rewrites)?;
-            Ok(Expr::TryCast(TryCast::new(
+            Ok(Expr::TryCast(TryCast::new_from_field(
                 Box::new(expr),
-                try_cast.data_type,
+                try_cast.field,
             )))
         }
         Expr::ScalarFunction(sf) => {
@@ -562,7 +562,10 @@ fn rewrite_table_scans_in_expr(
             let expr = rewrite_table_scans_in_expr(*unnest.expr, known_rewrites)?;
             Ok(Expr::Unnest(Unnest::new(expr)))
         }
-        Expr::ScalarVariable(_, _) | Expr::Literal(_, _) | Expr::Placeholder(_) => Ok(expr),
+        Expr::ScalarVariable(_, _)
+        | Expr::Literal(_, _)
+        | Expr::Placeholder(_)
+        | Expr::LambdaVariable(_) => Ok(expr),
         Expr::SetComparison(sc) => {
             let expr = rewrite_table_scans_in_expr(*sc.expr, known_rewrites)?;
             let subquery_plan = rewrite_table_scans(&sc.subquery.subquery, known_rewrites)?;
@@ -583,6 +586,20 @@ fn rewrite_table_scans_in_expr(
                 sc.op,
                 sc.quantifier,
             )))
+        }
+        Expr::HigherOrderFunction(hof) => {
+            let args = hof
+                .args
+                .into_iter()
+                .map(|e| rewrite_table_scans_in_expr(e, known_rewrites))
+                .collect::<Result<Vec<Expr>>>()?;
+            Ok(Expr::HigherOrderFunction(HigherOrderFunction::new(
+                hof.func, args,
+            )))
+        }
+        Expr::Lambda(lambda) => {
+            let body = rewrite_table_scans_in_expr(*lambda.body, known_rewrites)?;
+            Ok(Expr::Lambda(Lambda::new(lambda.params, body)))
         }
     }
 }

--- a/datafusion-federation/src/sql/ast_analyzer.rs
+++ b/datafusion-federation/src/sql/ast_analyzer.rs
@@ -100,6 +100,7 @@ impl VisitorMut for TableArgReplace {
                         explicit: true,
                         name: Ident::new(table.table()),
                         columns: vec![],
+                        at: None,
                     })
                 }
             }

--- a/datafusion-federation/src/sql/mod.rs
+++ b/datafusion-federation/src/sql/mod.rs
@@ -247,7 +247,7 @@ fn gather_analyzers(
             let provider = get_table_source(&table.source)
                 .expect("caller is virtual exec so this is valid")
                 .expect("caller is virtual exec so this is valid");
-            if let Some(source) = provider.as_any().downcast_ref::<SQLTableSource>() {
+            if let Some(source) = (provider.as_ref() as &dyn Any).downcast_ref::<SQLTableSource>() {
                 if let Some(analyzer) = source.table.logical_optimizer() {
                     logical_optimizers.push(analyzer);
                 }
@@ -373,10 +373,6 @@ impl ExecutionPlan for VirtualExecutionPlan {
         "sql_federation_exec"
     }
 
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         self.schema()
     }
@@ -405,8 +401,8 @@ impl ExecutionPlan for VirtualExecutionPlan {
         &self.props
     }
 
-    fn partition_statistics(&self, _partition: Option<usize>) -> Result<Statistics> {
-        Ok(self.statistics.clone())
+    fn partition_statistics(&self, _partition: Option<usize>) -> Result<Arc<Statistics>> {
+        Ok(Arc::new(self.statistics.clone()))
     }
 
     fn metrics(&self) -> Option<MetricsSet> {
@@ -654,8 +650,7 @@ mod tests {
 
         let _ = physical_plan.apply(|node| {
             if node.name() == "sql_federation_exec" {
-                let node = node
-                    .as_any()
+                let node = (node.as_ref() as &dyn Any)
                     .downcast_ref::<VirtualExecutionPlan>()
                     .unwrap();
 
@@ -744,8 +739,7 @@ mod tests {
 
         let _ = physical_plan.apply(|node| {
             if node.name() == "sql_federation_exec" {
-                let node = node
-                    .as_any()
+                let node = (node.as_ref() as &dyn Any)
                     .downcast_ref::<VirtualExecutionPlan>()
                     .unwrap();
 
@@ -849,8 +843,7 @@ mod tests {
         let mut final_queries = vec![];
         let _ = physical_plan.apply(|node| {
             if node.name() == "sql_federation_exec" {
-                let node = node
-                    .as_any()
+                let node = (node.as_ref() as &dyn Any)
                     .downcast_ref::<VirtualExecutionPlan>()
                     .unwrap();
                 final_queries.push(node.final_sql()?);

--- a/datafusion-federation/src/sql/schema.rs
+++ b/datafusion-federation/src/sql/schema.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, sync::Arc};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use datafusion::{catalog::SchemaProvider, datasource::TableProvider, error::Result};
@@ -77,10 +77,6 @@ impl SQLSchemaProvider {
 
 #[async_trait]
 impl SchemaProvider for SQLSchemaProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn table_names(&self) -> Vec<String> {
         self.tables
             .iter()
@@ -120,10 +116,6 @@ impl MultiSchemaProvider {
 
 #[async_trait]
 impl SchemaProvider for MultiSchemaProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn table_names(&self) -> Vec<String> {
         self.children.iter().flat_map(|p| p.table_names()).collect()
     }

--- a/datafusion-federation/src/sql/table.rs
+++ b/datafusion-federation/src/sql/table.rs
@@ -156,10 +156,6 @@ impl SQLTableSource {
 }
 
 impl TableSource for SQLTableSource {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         self.table.schema()
     }

--- a/datafusion-federation/src/table_provider.rs
+++ b/datafusion-federation/src/table_provider.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, borrow::Cow, sync::Arc};
+use std::{borrow::Cow, sync::Arc};
 
 use async_trait::async_trait;
 use datafusion::{
@@ -47,9 +47,6 @@ impl FederatedTableProviderAdaptor {
 
 #[async_trait]
 impl TableProvider for FederatedTableProviderAdaptor {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
     fn schema(&self) -> SchemaRef {
         if let Some(table_provider) = &self.table_provider {
             return table_provider.schema();


### PR DESCRIPTION
- Remove `as_any` from traits (matches DF54 traits). (Breaking change)
- Make partition_statistics return `Arc<Statistics>`
- `Cast` does not have a `data_type` field anymore, so switch to `Cast::new_from_field`
- Account for new Expr variants `LambdaVariable`, `HigherOrderFunction`, `Lambda`