### PR TITLE
Upgrade to Datafusion 55

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ readme = "README.md"
 repository = "https://github.com/datafusion-contrib/datafusion-federation"
 
 [workspace.dependencies]
-arrow-json = "58.3"
+arrow-json = "59.2"
 async-stream = "0.3"
 async-trait = "0.1"
-datafusion = "54"
+datafusion = "55"
 datafusion-federation = { path = "./datafusion-federation", version = "0.5.5" }
 futures = "0.3"
 tokio = { version = "1.41", features = ["full"] }

--- a/datafusion-federation/src/plan_node.rs
+++ b/datafusion-federation/src/plan_node.rs
@@ -7,10 +7,14 @@ use std::{
 
 use async_trait::async_trait;
 use datafusion::{
+    catalog::Session,
     common::DFSchemaRef,
     error::{DataFusionError, Result},
-    execution::context::{QueryPlanner, SessionState},
-    logical_expr::{Expr, LogicalPlan, UserDefinedLogicalNode, UserDefinedLogicalNodeCore},
+    execution::context::QueryPlanner,
+    logical_expr::{
+        physical_planning_context::PhysicalPlanningContext, Expr, LogicalPlan,
+        UserDefinedLogicalNode, UserDefinedLogicalNodeCore,
+    },
     physical_plan::ExecutionPlan,
     physical_planner::{DefaultPhysicalPlanner, ExtensionPlanner, PhysicalPlanner},
 };
@@ -86,7 +90,7 @@ impl QueryPlanner for FederatedQueryPlanner {
     async fn create_physical_plan(
         &self,
         logical_plan: &LogicalPlan,
-        session_state: &SessionState,
+        session_state: &dyn Session,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         // Get provider here?
 
@@ -105,7 +109,7 @@ pub trait FederationPlanner: Send + Sync {
     async fn plan_federation(
         &self,
         node: &FederatedPlanNode,
-        session_state: &SessionState,
+        session_state: &dyn Session,
     ) -> Result<Arc<dyn ExecutionPlan>>;
 }
 
@@ -153,7 +157,8 @@ impl ExtensionPlanner for FederatedPlanner {
         node: &dyn UserDefinedLogicalNode,
         logical_inputs: &[&LogicalPlan],
         physical_inputs: &[Arc<dyn ExecutionPlan>],
-        session_state: &SessionState,
+        session_state: &dyn Session,
+        _planning_ctx: &PhysicalPlanningContext,
     ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
         let dc_node = node.as_any().downcast_ref::<FederatedPlanNode>();
         if let Some(fed_node) = dc_node {

--- a/datafusion-federation/src/schema_cast/mod.rs
+++ b/datafusion-federation/src/schema_cast/mod.rs
@@ -132,8 +132,14 @@ impl ExecutionPlan for SchemaCastScanExec {
         input_stats: &[Arc<Statistics>],
         _args: &StatisticsArgs,
     ) -> Result<Arc<Statistics>> {
-        // We always have a single child input
-        Ok(Arc::clone(&input_stats[0]))
+        if input_stats.len() == 1 {
+            Ok(Arc::clone(&input_stats[0]))
+        } else {
+            Err(DataFusionError::Execution(format!(
+                "{} expects exactly one input",
+                self.name()
+            )))
+        }
     }
 
     fn metrics(&self) -> Option<MetricsSet> {

--- a/datafusion-federation/src/schema_cast/mod.rs
+++ b/datafusion-federation/src/schema_cast/mod.rs
@@ -1,5 +1,6 @@
 use async_stream::stream;
 use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::common::tree_node::TreeNodeRecursion;
 use datafusion::common::Statistics;
 use datafusion::config::ConfigOptions;
 use datafusion::error::{DataFusionError, Result};
@@ -8,8 +9,8 @@ use datafusion::physical_plan::filter_pushdown::{FilterDescription, FilterPushdo
 use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PhysicalExpr,
-    PlanProperties,
+    ChildStats, DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PhysicalExpr,
+    PlanProperties, StatisticsArgs,
 };
 use futures::StreamExt;
 use std::clone::Clone;
@@ -122,8 +123,16 @@ impl ExecutionPlan for SchemaCastScanExec {
         )))
     }
 
-    fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
-        self.input.partition_statistics(partition)
+    fn child_stats_requests(&self, partition: Option<usize>) -> Vec<ChildStats> {
+        vec![ChildStats::At(partition)]
+    }
+
+    fn statistics_from_inputs(
+        &self,
+        input_stats: &[Arc<Statistics>],
+        _args: &StatisticsArgs,
+    ) -> Result<Arc<Statistics>> {
+        Ok(Arc::clone(&input_stats[0]))
     }
 
     fn metrics(&self) -> Option<MetricsSet> {
@@ -137,5 +146,12 @@ impl ExecutionPlan for SchemaCastScanExec {
         _config: &ConfigOptions,
     ) -> Result<FilterDescription> {
         FilterDescription::from_children(parent_filters, &self.children())
+    }
+
+    fn apply_expressions(
+        &self,
+        _f: &mut dyn FnMut(&Arc<dyn PhysicalExpr>) -> Result<TreeNodeRecursion>,
+    ) -> Result<TreeNodeRecursion> {
+        Ok(TreeNodeRecursion::Continue)
     }
 }

--- a/datafusion-federation/src/schema_cast/mod.rs
+++ b/datafusion-federation/src/schema_cast/mod.rs
@@ -132,6 +132,7 @@ impl ExecutionPlan for SchemaCastScanExec {
         input_stats: &[Arc<Statistics>],
         _args: &StatisticsArgs,
     ) -> Result<Arc<Statistics>> {
+        // We always have a single child input
         Ok(Arc::clone(&input_stats[0]))
     }
 

--- a/datafusion-federation/src/schema_cast/mod.rs
+++ b/datafusion-federation/src/schema_cast/mod.rs
@@ -153,6 +153,7 @@ impl ExecutionPlan for SchemaCastScanExec {
         &self,
         _f: &mut dyn FnMut(&Arc<dyn PhysicalExpr>) -> Result<TreeNodeRecursion>,
     ) -> Result<TreeNodeRecursion> {
+        // We have no expressions, so per the docs for `apply_expressions`, we should return `Continue`
         Ok(TreeNodeRecursion::Continue)
     }
 }

--- a/datafusion-federation/src/sql/analyzer.rs
+++ b/datafusion-federation/src/sql/analyzer.rs
@@ -1,7 +1,7 @@
 use std::{any::Any, collections::HashMap, sync::Arc};
 
 use datafusion::{
-    common::{Column, Spans},
+    common::{Column, Spans, TableReference},
     logical_expr::{
         expr::{
             AggregateFunction, AggregateFunctionParams, Alias, Exists, HigherOrderFunction, InList,
@@ -11,7 +11,6 @@ use datafusion::{
         Between, BinaryExpr, Case, Cast, Expr, GroupingSet, Like, Limit, LogicalPlan, Subquery,
         TryCast,
     },
-    sql::TableReference,
 };
 
 use crate::get_table_source;

--- a/datafusion-federation/src/sql/ast_analyzer.rs
+++ b/datafusion-federation/src/sql/ast_analyzer.rs
@@ -1,11 +1,9 @@
 use std::ops::ControlFlow;
 
-use datafusion::sql::{
-    sqlparser::ast::{
-        FunctionArg, Ident, ObjectName, Statement, TableAlias, TableFactor, TableFunctionArgs,
-        VisitMut, VisitorMut,
-    },
-    TableReference,
+use datafusion::common::TableReference;
+use datafusion::sql::sqlparser::ast::{
+    FunctionArg, Ident, ObjectName, Statement, TableAlias, TableFactor, TableFunctionArgs,
+    VisitMut, VisitorMut,
 };
 
 use super::AstAnalyzer;
@@ -22,7 +20,7 @@ pub fn replace_table_args_analyzer(mut visitor: TableArgReplace) -> AstAnalyzer 
 ///
 /// ```rust
 /// use datafusion::sql::sqlparser::ast::{FunctionArg, Expr, Value};
-/// use datafusion::sql::TableReference;
+/// use datafusion::common::TableReference;
 /// use datafusion_federation::sql::ast_analyzer::TableArgReplace;
 ///
 /// let mut analyzer = TableArgReplace::default().with(

--- a/datafusion-federation/src/sql/mod.rs
+++ b/datafusion-federation/src/sql/mod.rs
@@ -11,24 +11,26 @@ use analyzer::RewriteTableScanAnalyzer;
 use async_trait::async_trait;
 use datafusion::{
     arrow::datatypes::{Schema, SchemaRef},
+    catalog::Session,
     common::{
-        tree_node::{Transformed, TreeNode},
+        tree_node::{Transformed, TreeNode, TreeNodeRecursion},
         Statistics,
     },
     config::ConfigOptions,
     error::{DataFusionError, Result},
-    execution::{context::SessionState, TaskContext},
+    execution::TaskContext,
     logical_expr::{Extension, LogicalPlan},
     optimizer::{optimizer::Optimizer, OptimizerConfig, OptimizerRule},
     physical_expr::EquivalenceProperties,
     physical_plan::{
+        apply_expression_roots,
         execution_plan::{Boundedness, EmissionType},
         filter_pushdown::{
             ChildPushdownResult, FilterPushdownPhase, FilterPushdownPropagation, PushedDown,
         },
         metrics::MetricsSet,
         DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PhysicalExpr, PlanProperties,
-        SendableRecordBatchStream,
+        SendableRecordBatchStream, StatisticsArgs,
     },
     sql::{sqlparser::ast::Statement, unparser::Unparser},
 };
@@ -145,7 +147,7 @@ impl FederationPlanner for SQLFederationPlanner {
     async fn plan_federation(
         &self,
         node: &FederatedPlanNode,
-        _session_state: &SessionState,
+        _session_state: &dyn Session,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let schema = Arc::new(node.plan().schema().as_arrow().clone());
         let plan = node.plan().clone();
@@ -401,7 +403,11 @@ impl ExecutionPlan for VirtualExecutionPlan {
         &self.props
     }
 
-    fn partition_statistics(&self, _partition: Option<usize>) -> Result<Arc<Statistics>> {
+    fn statistics_from_inputs(
+        &self,
+        _input_stats: &[Arc<Statistics>],
+        _args: &StatisticsArgs,
+    ) -> Result<Arc<Statistics>> {
         Ok(Arc::new(self.statistics.clone()))
     }
 
@@ -438,6 +444,13 @@ impl ExecutionPlan for VirtualExecutionPlan {
             updated_node: Some(Arc::new(node)),
         })
     }
+
+    fn apply_expressions(
+        &self,
+        f: &mut dyn FnMut(&Arc<dyn PhysicalExpr>) -> Result<TreeNodeRecursion>,
+    ) -> Result<TreeNodeRecursion> {
+        apply_expression_roots(&self.filters, f)
+    }
 }
 
 #[cfg(test)]
@@ -454,10 +467,10 @@ mod tests {
     use async_trait::async_trait;
     use datafusion::arrow::datatypes::{Schema, SchemaRef};
     use datafusion::common::tree_node::TreeNodeRecursion;
+    use datafusion::common::TableReference;
     use datafusion::execution::SendableRecordBatchStream;
     use datafusion::sql::unparser::dialect::Dialect;
     use datafusion::sql::unparser::{self};
-    use datafusion::sql::TableReference;
     use datafusion::{
         arrow::datatypes::{DataType, Field},
         datasource::TableProvider,

--- a/datafusion-federation/src/sql/table.rs
+++ b/datafusion-federation/src/sql/table.rs
@@ -2,10 +2,10 @@ use crate::sql::SQLFederationProvider;
 use crate::FederatedTableSource;
 use crate::FederationProvider;
 use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::common::TableReference;
 use datafusion::error::Result;
 use datafusion::logical_expr::TableSource;
 use datafusion::logical_expr::TableType;
-use datafusion::sql::TableReference;
 use std::any::Any;
 use std::sync::Arc;
 
@@ -22,7 +22,7 @@ use super::RemoteTableRef;
 pub trait SQLTable: std::fmt::Debug + Send + Sync {
     /// Returns a reference as a trait object.
     fn as_any(&self) -> &dyn Any;
-    /// Provides the [`TableReference`](`datafusion::sql::TableReference`) used to identify the table in SQL queries.
+    /// Provides the [`TableReference`](`datafusion::common::TableReference`) used to identify the table in SQL queries.
     /// This TableReference is used for registering the table with the [`SQLSchemaProvider`](`super::SQLSchemaProvider`).
     /// If the table provider is registered in the Datafusion context under a different name,
     /// the logical plan will be rewritten to use this table reference during execution.
@@ -57,7 +57,7 @@ impl RemoteTable {
     ///
     /// Examples:
     /// ```ignore
-    /// use datafusion::sql::TableReference;
+    /// use datafusion::common::TableReference;
     ///
     /// RemoteTable::new("myschema.table".try_into()?, schema);
     /// RemoteTable::new(r#"myschema."Table""#.try_into()?, schema);

--- a/datafusion-federation/src/sql/table_reference.rs
+++ b/datafusion-federation/src/sql/table_reference.rs
@@ -1,15 +1,13 @@
 use std::sync::Arc;
 
 use datafusion::{
+    common::TableReference,
     error::DataFusionError,
-    sql::{
-        sqlparser::{
-            self,
-            ast::{FunctionArg, ObjectNamePart},
-            dialect::{Dialect, GenericDialect},
-            tokenizer::Token,
-        },
-        TableReference,
+    sql::sqlparser::{
+        self,
+        ast::{FunctionArg, ObjectNamePart},
+        dialect::{Dialect, GenericDialect},
+        tokenizer::Token,
     },
 };
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.94.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
- Datafusion 55 is on Rust MSRV 1.94, so bump toolchain
- `TableReference` re-export was removed from `datafusion::sql`, so now using the definition from `datafusion::common::TableReference`
- Implement `child_stats_requests` + `statistics_from_inputs` instead of the deprecated `partition_statistics`. `VirtualExecutionPlan` uses the default impl of `child_stats_requests` which skips computing statistics of children, since `VirtualExecutionPlan` already gets statistics in its `new` method
- Implement `apply_expressions` which is now required

I followed the upgrade guide https://datafusion.apache.org/library-user-guide/upgrading/55.0.0.html